### PR TITLE
:sparkles: Better lighting & cast shadow & multiple lights handling

### DIFF
--- a/include/Generation/tools.hpp
+++ b/include/Generation/tools.hpp
@@ -9,7 +9,7 @@
 
 // Create Image
 void generateImage(sf::RenderWindow &window, sf::Image &image,
-    std::unique_ptr<Light> &Light);
+    std::shared_ptr<Light> &Light);
 
 // Render image
 void displayImage(sf::RenderWindow &window, sf::Image &image);

--- a/include/Generation/tools.hpp
+++ b/include/Generation/tools.hpp
@@ -8,8 +8,7 @@
 #include <SFML/Window.hpp>
 
 // Create Image
-void generateImage(sf::RenderWindow &window, sf::Image &image,
-    std::shared_ptr<Light> &Light);
+void generateImage(sf::RenderWindow &window, sf::Image &image);
 
 // Render image
 void displayImage(sf::RenderWindow &window, sf::Image &image);

--- a/main.cpp
+++ b/main.cpp
@@ -25,13 +25,15 @@ static void setupAndRun(sf::RenderWindow &window, sf::Image &image) {
         "./libs/primitive_sphere.so", "getPrimitive");
 
     RayTracer::Scene::i->Lights.push_back(dlLoader<Light>::getLib(
-        "./libs/light_spot.so", "getLight"));  // Add light to Lights vector
+        "./libs/light_spot.so", "getLight"));
+    RayTracer::Scene::i->Lights.push_back(dlLoader<Light>::getLib(
+        "./libs/light_ambient.so", "getLight"));
 
     RayTracer::Scene::i->ObjectHead->AddChildren(
         dlLoader<Prim>::getLib("./libs/primitive_sphere.so", "getPrimitive"));
 
     computeTreeValues(RayTracer::Scene::i->ObjectHead);
-    generateImage(window, image, RayTracer::Scene::i->Lights[0]);
+    generateImage(window, image);
     displayImage(window, image);
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -26,8 +26,8 @@ static void setupAndRun(sf::RenderWindow &window, sf::Image &image) {
     std::unique_ptr<Light> light = dlLoader<Light>::getLib(
         "./libs/light_spot.so", "getLight");
 
-    //RayTracer::Scene::i->ObjectHead->AddChildren(
-    //    dlLoader<Prim>::getLib("./libs/primitive_sphere.so", "getPrimitive"));
+    RayTracer::Scene::i->ObjectHead->AddChildren(
+        dlLoader<Prim>::getLib("./libs/primitive_sphere.so", "getPrimitive"));
 
     computeTreeValues(RayTracer::Scene::i->ObjectHead);
     generateImage(window, image, light);

--- a/main.cpp
+++ b/main.cpp
@@ -24,10 +24,8 @@ static void setupAndRun(sf::RenderWindow &window, sf::Image &image) {
     RayTracer::Scene::i->ObjectHead = dlLoader<Prim>::getLib(
         "./libs/primitive_sphere.so", "getPrimitive");
 
-    RayTracer::Scene::i->Lights.push_back(dlLoader<Light>::getLib(
+    RayTracer::Scene::i->ObjectHead->AddChildren(dlLoader<Prim>::getLib(
         "./libs/light_spot.so", "getLight"));
-    RayTracer::Scene::i->Lights.push_back(dlLoader<Light>::getLib(
-        "./libs/light_ambient.so", "getLight"));
 
     RayTracer::Scene::i->ObjectHead->AddChildren(
         dlLoader<Prim>::getLib("./libs/primitive_sphere.so", "getPrimitive"));

--- a/main.cpp
+++ b/main.cpp
@@ -23,14 +23,15 @@
 static void setupAndRun(sf::RenderWindow &window, sf::Image &image) {
     RayTracer::Scene::i->ObjectHead = dlLoader<Prim>::getLib(
         "./libs/primitive_sphere.so", "getPrimitive");
-    std::unique_ptr<Light> light = dlLoader<Light>::getLib(
-        "./libs/light_spot.so", "getLight");
+
+    RayTracer::Scene::i->Lights.push_back(dlLoader<Light>::getLib(
+        "./libs/light_spot.so", "getLight"));  // Add light to Lights vector
 
     RayTracer::Scene::i->ObjectHead->AddChildren(
         dlLoader<Prim>::getLib("./libs/primitive_sphere.so", "getPrimitive"));
 
     computeTreeValues(RayTracer::Scene::i->ObjectHead);
-    generateImage(window, image, light);
+    generateImage(window, image, RayTracer::Scene::i->Lights[0]);
     displayImage(window, image);
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -26,8 +26,8 @@ static void setupAndRun(sf::RenderWindow &window, sf::Image &image) {
     std::unique_ptr<Light> light = dlLoader<Light>::getLib(
         "./libs/light_spot.so", "getLight");
 
-    RayTracer::Scene::i->ObjectHead->AddChildren(
-        dlLoader<Prim>::getLib("./libs/primitive_sphere.so", "getPrimitive"));
+    //RayTracer::Scene::i->ObjectHead->AddChildren(
+    //    dlLoader<Prim>::getLib("./libs/primitive_sphere.so", "getPrimitive"));
 
     computeTreeValues(RayTracer::Scene::i->ObjectHead);
     generateImage(window, image, light);

--- a/src/3dDatas/Point3D.cpp
+++ b/src/3dDatas/Point3D.cpp
@@ -22,7 +22,16 @@ RayTracer::Vector3D RayTracer::Point3D::operator-(const Point3D &vec) {
     return Vector3D(x - vec.x, y - vec.y, z - vec.z);
 }
 
-float RayTracer::Point3D::distance(Point3D other) {
+bool RayTracer::Point3D::operator==(const Point3D &other) {
+    return (x == other.x && y == other.y && z == other.z);
+}
+
+bool RayTracer::Point3D::operator!=(const Point3D &other) {
+    return (x != other.x || y != other.y || z != other.z);
+}
+
+float RayTracer::Point3D::distance(Point3D other)
+{
     return std::sqrt(std::pow(x - other.x, 2) +
                     std::pow(y - other.y, 2) +
                     std::pow(z - other.z, 2));

--- a/src/3dDatas/Point3D.cpp
+++ b/src/3dDatas/Point3D.cpp
@@ -30,8 +30,7 @@ bool RayTracer::Point3D::operator!=(const Point3D &other) {
     return (x != other.x || y != other.y || z != other.z);
 }
 
-float RayTracer::Point3D::distance(Point3D other)
-{
+float RayTracer::Point3D::distance(Point3D other) {
     return std::sqrt(std::pow(x - other.x, 2) +
                     std::pow(y - other.y, 2) +
                     std::pow(z - other.z, 2));

--- a/src/3dDatas/Point3D.hpp
+++ b/src/3dDatas/Point3D.hpp
@@ -14,6 +14,8 @@ class Point3D {
     Point3D operator+(const Point3D& other);
     Point3D operator-(const Vector3D& vec);
     Vector3D operator-(const Point3D& vec);
+    bool operator==(const Point3D& other);
+    bool operator!=(const Point3D& other);
 
     float distance(Point3D other);
 };

--- a/src/3dDatas/Vector3D.cpp
+++ b/src/3dDatas/Vector3D.cpp
@@ -25,13 +25,14 @@ double RayTracer::Vector3D::dot(const Vector3D &other) {
     return x * other.x + y * other.y + z * other.z;
 }
 
-void RayTracer::Vector3D::normalize() {
+RayTracer::Vector3D &RayTracer::Vector3D::normalize() {
     double len = length();
     if (len != 0) {
         x /= len;
         y /= len;
         z /= len;
     }
+    return *this;
 }
 
 #pragma endregion TOOLS

--- a/src/3dDatas/Vector3D.hpp
+++ b/src/3dDatas/Vector3D.hpp
@@ -15,7 +15,7 @@ class Vector3D {
 
     double length();
     double dot(const Vector3D& other);
-    void normalize();
+    Vector3D &normalize();
 
     // Vector3D
     Vector3D operator+(const Vector3D& other);

--- a/src/Draw/computeTreeValues.cpp
+++ b/src/Draw/computeTreeValues.cpp
@@ -12,7 +12,7 @@ std::shared_ptr<Prim> parent) {
         head->setPosition(head->getPosition() + parent->getPosition());
     if (dynamic_cast<Light *>(head.get()) != nullptr) {
         RayTracer::Scene::i->Lights.push_back(
-            std::shared_ptr<Light>(dynamic_cast<Light *>(head.get())));
+            std::static_pointer_cast<Light>(head));
     }
     for (std::shared_ptr<Prim> &o : head->getChildrens())
         computeTreeValues(o, head);

--- a/src/Draw/computeTreeValues.cpp
+++ b/src/Draw/computeTreeValues.cpp
@@ -4,11 +4,16 @@
 #include "Primitive/I_Primitive.hpp"
 #include "3dDatas/Point3D.hpp"
 #include "Consts/const.hpp"
+#include "Scene/Scene.hpp"
 
 void computeTreeValues(std::shared_ptr<Prim> head,
 std::shared_ptr<Prim> parent) {
     if (parent != nullptr)
         head->setPosition(head->getPosition() + parent->getPosition());
+    if (dynamic_cast<Light *>(head.get()) != nullptr) {
+        RayTracer::Scene::i->Lights.push_back(
+            std::shared_ptr<Light>(dynamic_cast<Light *>(head.get())));
+    }
     for (std::shared_ptr<Prim> &o : head->getChildrens())
         computeTreeValues(o, head);
 }

--- a/src/Draw/draw.cpp
+++ b/src/Draw/draw.cpp
@@ -44,16 +44,12 @@ std::shared_ptr<Prim> &s, std::unique_ptr<Light> &Light, double &luminescence) {
     RayTracer::Vector3D localNormal = (intersection - s->getPosition()).normalize();
 
     double angle = std::acos(localNormal.dot(lightDir));
-    luminescence = Light->getLuminescence(angle);
+    luminescence = Light->getLuminescence(angle, (Light->getPosition() - intersection).length());
 
     if (angle > M_PI / 2) {
         luminescence = 0;
     } else {
         luminescence *= (1 - (angle / (M_PI / 2)));
-        // Apply inverse square law for distance attenuation
-        double distance = (Light->getPosition() - intersection).length();
-        double attenuationFactor = 1.0 / (1.0 + 0.1 * distance + 0.01 * distance * distance);
-        luminescence *= attenuationFactor;
     }
 }
 

--- a/src/Draw/draw.cpp
+++ b/src/Draw/draw.cpp
@@ -44,11 +44,16 @@ std::shared_ptr<Prim> &s, std::unique_ptr<Light> &Light, double &luminescence) {
     RayTracer::Vector3D localNormal = (intersection - s->getPosition()).normalize();
 
     double angle = std::acos(localNormal.dot(lightDir));
+    luminescence = Light->getLuminescence(angle);
 
-    if (angle > M_PI / 2)
+    if (angle > M_PI / 2) {
         luminescence = 0;
-    else {
+    } else {
         luminescence *= (1 - (angle / (M_PI / 2)));
+        // Apply inverse square law for distance attenuation
+        double distance = (Light->getPosition() - intersection).length();
+        double attenuationFactor = 1.0 / (1.0 + 0.1 * distance + 0.01 * distance * distance);
+        luminescence *= attenuationFactor;
     }
 }
 
@@ -59,8 +64,8 @@ static void hit(sf::Image &image, int i, int j, RayTracer::Ray &ray,
         // Get base colors
         sf::Color origin = image.getPixel(i, j);
         sf::Color c = s->getMaterial()->getColorAt(i, j);
-        double luminescence = 1;
 
+        double luminescence = 0;
         editLuminescenceFromAngle(intersection, s, Light, luminescence);
 
         editColor(luminescence, c, origin, minRayLen, intersection, ray);

--- a/src/Draw/draw.cpp
+++ b/src/Draw/draw.cpp
@@ -85,20 +85,23 @@ float &minRayLength) {
         checkHitsAtPixel(i, j, r, image, o, minRayLength);
 }
 
+void generatePixelColumn(float i, RayTracer::Camera cam, sf::Image &image) {
+    for (float j = 0; j < HEIGHT; j++) {
+        float minRayLength = 10000000.f;
+
+        RayTracer::Ray r = cam.ray(i / WIDTH, j / HEIGHT);
+        checkHitsAtPixel(i, j, r, image,
+            RayTracer::Scene::i->ObjectHead, minRayLength);
+    }
+}
+
 void generateImage(sf::RenderWindow &window, sf::Image &image) {
     RayTracer::Camera cam;
     std::vector<std::thread> threadVector;
 
     for (float i = 0; i < WIDTH; i++) {
-        for (float j = 0; j < HEIGHT; j++) {
-            float minRayLength = 10000000.f;
-
-            RayTracer::Ray r = cam.ray(i / WIDTH, j / HEIGHT);
-            checkHitsAtPixel(i, j, r, image,
-                RayTracer::Scene::i->ObjectHead, minRayLength);
-        }
         threadVector.emplace_back(generatePixelColumn, i,
-            std::ref(cam), std::ref(image), std::ref(Light));
+            std::ref(cam), std::ref(image));
     }
     for (auto &t : threadVector) {
         if (t.joinable())

--- a/src/Draw/draw.cpp
+++ b/src/Draw/draw.cpp
@@ -40,11 +40,13 @@ static void editColor(double luminescence, sf::Color &c,
 
 static void editLuminescenceFromAngle(RayTracer::Point3D &intersection,
 std::shared_ptr<Prim> &s, std::unique_ptr<Light> &Light, double &luminescence) {
-    RayTracer::Vector3D lightDir = (Light->getPosition() - intersection).normalize();
-    RayTracer::Vector3D localNormal = (intersection - s->getPosition()).normalize();
+    RayTracer::Vector3D lightDir =
+        (Light->getPosition() - intersection).normalize();
+    RayTracer::Vector3D localNormal = s->getNormalAt(intersection);
 
     double angle = std::acos(localNormal.dot(lightDir));
-    luminescence = Light->getLuminescence(angle, (Light->getPosition() - intersection).length());
+    luminescence = Light->getLuminescence(angle,
+        (Light->getPosition() - intersection).length());
 
     if (angle > M_PI / 2) {
         luminescence = 0;

--- a/src/Draw/draw.cpp
+++ b/src/Draw/draw.cpp
@@ -38,28 +38,11 @@ static void editColor(double luminescence, sf::Color &c,
                     (b * percentA) + (origin.b * (1 - percentA)));
 }
 
-static void editLuminescenceFromAngle(RayTracer::Point3D &intersection,
-std::shared_ptr<Prim> &s, std::shared_ptr<Light> &Light, double &luminescence) {
-    RayTracer::Vector3D lightDir =
-        (Light->getPosition() - intersection).normalize();
-    RayTracer::Vector3D localNormal =
-        (intersection - s->getPosition()).normalize();
-
-    double angle = std::acos(localNormal.dot(lightDir));
-    double luminescencetmp = Light->getLuminescence(angle,
-        (Light->getPosition() - intersection).length());
-
-    if (angle < M_PI / 2) {
-        luminescencetmp *= (1 - (angle / (M_PI / 2)));
-        luminescence += luminescencetmp;
-    }
-}
-
 double computeLuminescence(RayTracer::Point3D &intersection,
 std::shared_ptr<Prim> &s) {
     double luminescence = 0;
     for (std::shared_ptr<Light> Light : RayTracer::Scene::i->Lights) {
-        editLuminescenceFromAngle(intersection, s, Light, luminescence);
+        luminescence += Light->getLuminescence(intersection, Light, s);
     }
     return luminescence;
 }

--- a/src/Draw/draw.cpp
+++ b/src/Draw/draw.cpp
@@ -48,9 +48,7 @@ std::shared_ptr<Prim> &s, std::unique_ptr<Light> &Light, double &luminescence) {
     luminescence = Light->getLuminescence(angle,
         (Light->getPosition() - intersection).length());
 
-    if (angle > M_PI / 2) {
-        luminescence = 0;
-    } else {
+    if (angle < M_PI / 2) {
         luminescence *= (1 - (angle / (M_PI / 2)));
     }
 }

--- a/src/Draw/draw.cpp
+++ b/src/Draw/draw.cpp
@@ -40,11 +40,14 @@ static void editColor(double luminescence, sf::Color &c,
 
 static void editLuminescenceFromAngle(RayTracer::Point3D &intersection,
 std::shared_ptr<Prim> &s, std::shared_ptr<Light> &Light, double &luminescence) {
-    RayTracer::Vector3D lightDir = (Light->getPosition() - intersection).normalize();
-    RayTracer::Vector3D localNormal = (intersection - s->getPosition()).normalize();
+    RayTracer::Vector3D lightDir =
+        (Light->getPosition() - intersection).normalize();
+    RayTracer::Vector3D localNormal =
+        (intersection - s->getPosition()).normalize();
 
     double angle = std::acos(localNormal.dot(lightDir));
-    double luminescencetmp = Light->getLuminescence(angle, (Light->getPosition() - intersection).length());
+    double luminescencetmp = Light->getLuminescence(angle,
+        (Light->getPosition() - intersection).length());
 
     if (angle < M_PI / 2) {
         luminescencetmp *= (1 - (angle / (M_PI / 2)));

--- a/src/Draw/draw.cpp
+++ b/src/Draw/draw.cpp
@@ -45,11 +45,12 @@ std::shared_ptr<Prim> &s, std::unique_ptr<Light> &Light, double &luminescence) {
     RayTracer::Vector3D localNormal = s->getNormalAt(intersection);
 
     double angle = std::acos(localNormal.dot(lightDir));
-    luminescence = Light->getLuminescence(angle,
+    double luminescencetmp = Light->getLuminescence(angle,
         (Light->getPosition() - intersection).length());
 
     if (angle < M_PI / 2) {
-        luminescence *= (1 - (angle / (M_PI / 2)));
+        luminescencetmp *= (1 - (angle / (M_PI / 2)));
+        luminescence += luminescencetmp;
     }
 }
 

--- a/src/Interfaces/Light/A_Light.cpp
+++ b/src/Interfaces/Light/A_Light.cpp
@@ -57,6 +57,12 @@ RayTracer::Vector3D RayTracer::A_Lights::getNormalAt(RayTracer::Point3D point) {
     return RayTracer::Vector3D(0, 0, 0);
 }
 
+bool RayTracer::A_Lights::hits(RayTracer::Ray ray,
+    RayTracer::Point3D &intersection) {
+    (void) ray;
+    (void) intersection;
+    return false;
+}
 
 float RayTracer::A_Lights::getIntensity() {
     return intensity;

--- a/src/Interfaces/Light/A_Light.cpp
+++ b/src/Interfaces/Light/A_Light.cpp
@@ -52,6 +52,12 @@ float RayTracer::A_Lights::getLuminescence(float angle, float distance) {
     return intensity / (distance * distance);
 }
 
+RayTracer::Vector3D RayTracer::A_Lights::getNormalAt(RayTracer::Point3D point) {
+    (void) point;
+    return RayTracer::Vector3D(0, 0, 0);
+}
+
+
 float RayTracer::A_Lights::getIntensity() {
     return intensity;
 }

--- a/src/Interfaces/Light/A_Light.cpp
+++ b/src/Interfaces/Light/A_Light.cpp
@@ -47,9 +47,13 @@ void RayTracer::A_Lights::setScale(Point3D scale) {
     this->scale = scale;
 }
 
-float RayTracer::A_Lights::getLuminescence(float angle, float distance) {
-    (void) angle;
-    return intensity / (distance * distance);
+float RayTracer::A_Lights::getLuminescence(
+    RayTracer::Point3D intersection, std::shared_ptr<I_Light> Light,
+    std::shared_ptr<I_Primitive> obj) {
+    (void) intersection;
+    (void) Light;
+    (void) obj;
+    return intensity;
 }
 
 RayTracer::Vector3D RayTracer::A_Lights::getNormalAt(RayTracer::Point3D point) {

--- a/src/Interfaces/Light/A_Light.cpp
+++ b/src/Interfaces/Light/A_Light.cpp
@@ -47,9 +47,9 @@ void RayTracer::A_Lights::setScale(Point3D scale) {
     this->scale = scale;
 }
 
-float RayTracer::A_Lights::getLuminescence(float angle) {
+float RayTracer::A_Lights::getLuminescence(float angle, float distance) {
     (void) angle;
-    return intensity;
+    return intensity / (distance * distance);
 }
 
 float RayTracer::A_Lights::getIntensity() {

--- a/src/Interfaces/Light/A_Light.cpp
+++ b/src/Interfaces/Light/A_Light.cpp
@@ -47,9 +47,9 @@ void RayTracer::A_Lights::setScale(Point3D scale) {
     this->scale = scale;
 }
 
-float RayTracer::A_Lights::getLuminescence(float distance, float angle) {
+float RayTracer::A_Lights::getLuminescence(float angle) {
     (void) angle;
-    return intensity / distance;
+    return intensity;
 }
 
 float RayTracer::A_Lights::getIntensity() {

--- a/src/Interfaces/Light/A_Light.hpp
+++ b/src/Interfaces/Light/A_Light.hpp
@@ -31,7 +31,8 @@ class A_Lights : public I_Light {
     Point3D getScale() override;
     void setScale(Point3D scale) override;
 
-    float getLuminescence(float angle, float distance) = 0;
+    float getLuminescence(RayTracer::Point3D intersection,
+        std::shared_ptr<I_Light> Light, std::shared_ptr<I_Primitive> obj) = 0;
     float getIntensity() override;
     float getAngle() override;
     Vector3D getNormalAt(Point3D point) override;

--- a/src/Interfaces/Light/A_Light.hpp
+++ b/src/Interfaces/Light/A_Light.hpp
@@ -31,7 +31,7 @@ class A_Lights : public I_Light {
     Point3D getScale() override;
     void setScale(Point3D scale) override;
 
-    float getLuminescence(float distance, float angle) = 0;
+    float getLuminescence(float angle) = 0;
     float getIntensity() override;
     float getAngle() override;
 

--- a/src/Interfaces/Light/A_Light.hpp
+++ b/src/Interfaces/Light/A_Light.hpp
@@ -35,6 +35,7 @@ class A_Lights : public I_Light {
     float getIntensity() override;
     float getAngle() override;
     Vector3D getNormalAt(Point3D point) override;
+    bool hits(RayTracer::Ray ray, Point3D &intersection) override;
 
     class LightError : public std::exception {
      private:

--- a/src/Interfaces/Light/A_Light.hpp
+++ b/src/Interfaces/Light/A_Light.hpp
@@ -31,7 +31,7 @@ class A_Lights : public I_Light {
     Point3D getScale() override;
     void setScale(Point3D scale) override;
 
-    float getLuminescence(float angle) = 0;
+    float getLuminescence(float angle, float distance) = 0;
     float getIntensity() override;
     float getAngle() override;
 

--- a/src/Interfaces/Light/A_Light.hpp
+++ b/src/Interfaces/Light/A_Light.hpp
@@ -34,6 +34,7 @@ class A_Lights : public I_Light {
     float getLuminescence(float angle, float distance) = 0;
     float getIntensity() override;
     float getAngle() override;
+    Vector3D getNormalAt(Point3D point) override;
 
     class LightError : public std::exception {
      private:

--- a/src/Interfaces/Light/I_Light.hpp
+++ b/src/Interfaces/Light/I_Light.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <memory>
+
 #include "Interfaces/Primitive/I_Primitive.hpp"
 
 namespace RayTracer {
@@ -6,7 +8,7 @@ class I_Light : public I_Primitive {
  public:
     virtual ~I_Light() = default;
     virtual float getLuminescence(RayTracer::Point3D intersection,
-std::shared_ptr<I_Light> Light, std::shared_ptr<I_Primitive> obj) = 0;
+        std::shared_ptr<I_Light> Light, std::shared_ptr<I_Primitive> obj) = 0;
     virtual float getIntensity() = 0;
     virtual float getAngle() = 0;
 };

--- a/src/Interfaces/Light/I_Light.hpp
+++ b/src/Interfaces/Light/I_Light.hpp
@@ -5,7 +5,7 @@ namespace RayTracer {
 class I_Light : public I_Primitive {
  public:
     virtual ~I_Light() = default;
-    virtual float getLuminescence(float distance, float angle) = 0;
+    virtual float getLuminescence(float angle) = 0;
     virtual float getIntensity() = 0;
     virtual float getAngle() = 0;
 };

--- a/src/Interfaces/Light/I_Light.hpp
+++ b/src/Interfaces/Light/I_Light.hpp
@@ -5,7 +5,8 @@ namespace RayTracer {
 class I_Light : public I_Primitive {
  public:
     virtual ~I_Light() = default;
-    virtual float getLuminescence(float angle, float distance) = 0;
+    virtual float getLuminescence(RayTracer::Point3D intersection,
+std::shared_ptr<I_Light> Light, std::shared_ptr<I_Primitive> obj) = 0;
     virtual float getIntensity() = 0;
     virtual float getAngle() = 0;
 };

--- a/src/Interfaces/Light/I_Light.hpp
+++ b/src/Interfaces/Light/I_Light.hpp
@@ -5,7 +5,7 @@ namespace RayTracer {
 class I_Light : public I_Primitive {
  public:
     virtual ~I_Light() = default;
-    virtual float getLuminescence(float angle) = 0;
+    virtual float getLuminescence(float angle, float distance) = 0;
     virtual float getIntensity() = 0;
     virtual float getAngle() = 0;
 };

--- a/src/Interfaces/Primitive/I_Primitive.hpp
+++ b/src/Interfaces/Primitive/I_Primitive.hpp
@@ -13,6 +13,7 @@ class I_Primitive {
     virtual void Init() = 0;
 
     virtual std::vector<std::shared_ptr<I_Primitive>> &getChildrens() = 0;
+    virtual Vector3D getNormalAt(Point3D point) = 0;
     virtual std::shared_ptr<I_Primitive> &AddChildren(
         std::shared_ptr<I_Primitive> child) = 0;
 

--- a/src/Lights/Ambient.cpp
+++ b/src/Lights/Ambient.cpp
@@ -12,7 +12,7 @@ Ambient::Ambient() {
 
 void Ambient::Init() {
     angle = 360;
-    intensity = 0.2f;
+    intensity = 0.3f;
     position = RayTracer::Point3D(-0.15f, 0.45f, -2.f);
 }
 

--- a/src/Lights/Ambient.cpp
+++ b/src/Lights/Ambient.cpp
@@ -16,9 +16,8 @@ void Ambient::Init() {
     position = RayTracer::Point3D(-0.15f, 0.45f, -2.f);
 }
 
-float Ambient::getLuminescence(float distance, float angle) {
+float Ambient::getLuminescence(float angle) {
     (void) angle;
-    (void) distance;
     return intensity;
 }
 

--- a/src/Lights/Ambient.cpp
+++ b/src/Lights/Ambient.cpp
@@ -16,8 +16,9 @@ void Ambient::Init() {
     position = RayTracer::Point3D(-0.15f, 0.45f, -2.f);
 }
 
-float Ambient::getLuminescence(float angle) {
+float Ambient::getLuminescence(float angle, float distance) {
     (void) angle;
+    (void) distance;
     return intensity;
 }
 

--- a/src/Lights/Ambient.cpp
+++ b/src/Lights/Ambient.cpp
@@ -21,9 +21,3 @@ float Ambient::getLuminescence(float angle, float distance) {
     (void) distance;
     return intensity;
 }
-
-bool Ambient::hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) {
-    (void) ray;
-    (void) intersection;
-    return false;
-}

--- a/src/Lights/Ambient.cpp
+++ b/src/Lights/Ambient.cpp
@@ -12,12 +12,14 @@ Ambient::Ambient() {
 
 void Ambient::Init() {
     angle = 360;
-    intensity = 0.3f;
+    intensity = 0.1f;
     position = RayTracer::Point3D(-0.15f, 0.45f, -2.f);
 }
 
-float Ambient::getLuminescence(float angle, float distance) {
-    (void) angle;
-    (void) distance;
+float Ambient::getLuminescence(RayTracer::Point3D intersection,
+std::shared_ptr<I_Light> Light, std::shared_ptr<I_Primitive> obj) {
+    (void) intersection;
+    (void) Light;
+    (void) obj;
     return intensity;
 }

--- a/src/Lights/Ambient.hpp
+++ b/src/Lights/Ambient.hpp
@@ -8,5 +8,7 @@ class Ambient : public RayTracer::A_Lights {
  public:
     Ambient();
     void Init() override;
-    float getLuminescence(float angle, float distance) override;
+    float getLuminescence(RayTracer::Point3D intersection,
+        std::shared_ptr<I_Light> Light,
+        std::shared_ptr<I_Primitive> obj) override;
 };

--- a/src/Lights/Ambient.hpp
+++ b/src/Lights/Ambient.hpp
@@ -9,5 +9,4 @@ class Ambient : public RayTracer::A_Lights {
     Ambient();
     void Init() override;
     float getLuminescence(float angle, float distance) override;
-    bool hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) override;
 };

--- a/src/Lights/Ambient.hpp
+++ b/src/Lights/Ambient.hpp
@@ -8,6 +8,6 @@ class Ambient : public RayTracer::A_Lights {
  public:
     Ambient();
     void Init() override;
-    float getLuminescence(float distance, float angle) override;
+    float getLuminescence(float angle) override;
     bool hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) override;
 };

--- a/src/Lights/Ambient.hpp
+++ b/src/Lights/Ambient.hpp
@@ -8,6 +8,6 @@ class Ambient : public RayTracer::A_Lights {
  public:
     Ambient();
     void Init() override;
-    float getLuminescence(float angle) override;
+    float getLuminescence(float angle, float distance) override;
     bool hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) override;
 };

--- a/src/Lights/Ambient.hpp
+++ b/src/Lights/Ambient.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <memory>
+
 #include "Interfaces/Light/A_Light.hpp"
 #include "3dDatas/Point3D.hpp"
 #include "3dDatas/Ray.hpp"

--- a/src/Lights/Spot.cpp
+++ b/src/Lights/Spot.cpp
@@ -12,14 +12,15 @@ Spot::Spot() {
 
 void Spot::Init() {
     angle = 360;
-    intensity = 2.f;
-    position = RayTracer::Point3D(0, 0, 15);
+    intensity = 40.f;
+    position = RayTracer::Point3D(0, 0, 10);
     rotation = RayTracer::Point3D(1, 0, 0);
 }
 
-float Spot::getLuminescence(float angle) {
-    (void) angle;
-    return intensity;
+float Spot::getLuminescence(float angle, float distance) {
+    if (angle > this->angle)
+        return 0;
+    return intensity / std::pow(distance, 2);
 }
 
 bool Spot::hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) {

--- a/src/Lights/Spot.cpp
+++ b/src/Lights/Spot.cpp
@@ -12,8 +12,8 @@ Spot::Spot() {
 
 void Spot::Init() {
     angle = 360;
-    intensity = 40.f;
-    position = RayTracer::Point3D(0, 0, 20);
+    intensity = 240.f;
+    position = RayTracer::Point3D(-25, 0, 0);
     rotation = RayTracer::Point3D(1, 0, 0);
 }
 

--- a/src/Lights/Spot.cpp
+++ b/src/Lights/Spot.cpp
@@ -13,7 +13,7 @@ Spot::Spot() {
 void Spot::Init() {
     angle = 360;
     intensity = 40.f;
-    position = RayTracer::Point3D(0, 0, 10);
+    position = RayTracer::Point3D(0, 0, 20);
     rotation = RayTracer::Point3D(1, 0, 0);
 }
 

--- a/src/Lights/Spot.cpp
+++ b/src/Lights/Spot.cpp
@@ -11,16 +11,15 @@ Spot::Spot() {
 }
 
 void Spot::Init() {
-    angle = 180;
-    intensity = 100.f;
-    position = RayTracer::Point3D(-10, 0, 20);
+    angle = 360;
+    intensity = 2.f;
+    position = RayTracer::Point3D(0, 0, 21);
     rotation = RayTracer::Point3D(1, 0, 0);
 }
 
-float Spot::getLuminescence(float distance, float angle) {
-    if (angle > this->angle)
-        return 0;
-    return intensity / std::pow(distance, 2);
+float Spot::getLuminescence(float angle) {
+    (void) angle;
+    return intensity;
 }
 
 bool Spot::hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) {

--- a/src/Lights/Spot.cpp
+++ b/src/Lights/Spot.cpp
@@ -11,9 +11,9 @@ Spot::Spot() {
 }
 
 void Spot::Init() {
-    angle = 70;
+    angle = 180;
     intensity = 50.f;
-    position = RayTracer::Point3D(10, 2, 20);
+    position = RayTracer::Point3D(10, 2, 32);
     rotation = RayTracer::Point3D(1, 0, 0);
 }
 

--- a/src/Lights/Spot.cpp
+++ b/src/Lights/Spot.cpp
@@ -12,8 +12,8 @@ Spot::Spot() {
 
 void Spot::Init() {
     angle = 360;
-    intensity = 140.f;
-    position = RayTracer::Point3D(0, 0, 10);
+    intensity = 20.f;
+    position = RayTracer::Point3D(0, 0, 20);
     rotation = RayTracer::Point3D(1, 0, 0);
 }
 

--- a/src/Lights/Spot.cpp
+++ b/src/Lights/Spot.cpp
@@ -13,7 +13,7 @@ Spot::Spot() {
 void Spot::Init() {
     angle = 180;
     intensity = 100.f;
-    position = RayTracer::Point3D(10, 10, 35);
+    position = RayTracer::Point3D(-10, 0, 20);
     rotation = RayTracer::Point3D(1, 0, 0);
 }
 

--- a/src/Lights/Spot.cpp
+++ b/src/Lights/Spot.cpp
@@ -17,8 +17,20 @@ void Spot::Init() {
     rotation = RayTracer::Point3D(1, 0, 0);
 }
 
-float Spot::getLuminescence(float angle, float distance) {
-    if (angle > this->angle)
-        return 0;
-    return intensity / std::pow(distance, 2);
+float Spot::getLuminescence(RayTracer::Point3D intersection,
+std::shared_ptr<I_Light> Light, std::shared_ptr<I_Primitive> obj) {
+    RayTracer::Vector3D lightDir =
+        (Light->getPosition() - intersection).normalize();
+    RayTracer::Vector3D localNormal = obj->getNormalAt(intersection);
+
+    double angle = std::acos(localNormal.dot(lightDir));
+    double distance = (Light->getPosition() - intersection).length();
+    double luminescencetmp = intensity;
+
+    if (angle < M_PI / 2 && angle < this->angle)
+        luminescencetmp *= (1 - (angle / (M_PI / 2)));
+    else
+        luminescencetmp = 0;
+
+    return luminescencetmp / std::pow(distance, 2);
 }

--- a/src/Lights/Spot.cpp
+++ b/src/Lights/Spot.cpp
@@ -13,7 +13,7 @@ Spot::Spot() {
 void Spot::Init() {
     angle = 360;
     intensity = 2.f;
-    position = RayTracer::Point3D(0, 0, 21);
+    position = RayTracer::Point3D(0, 0, 15);
     rotation = RayTracer::Point3D(1, 0, 0);
 }
 

--- a/src/Lights/Spot.cpp
+++ b/src/Lights/Spot.cpp
@@ -27,7 +27,7 @@ std::shared_ptr<I_Light> Light, std::shared_ptr<I_Primitive> obj) {
     double distance = (Light->getPosition() - intersection).length();
     double luminescencetmp = intensity;
 
-    if (angle < M_PI / 2 && angle < this->angle)
+    if (angle < M_PI / 2 && angle < this->angle * (M_PI / 180.0))
         luminescencetmp *= (1 - (angle / (M_PI / 2)));
     else
         luminescencetmp = 0;

--- a/src/Lights/Spot.cpp
+++ b/src/Lights/Spot.cpp
@@ -13,7 +13,7 @@ Spot::Spot() {
 void Spot::Init() {
     angle = 360;
     intensity = 20.f;
-    position = RayTracer::Point3D(0, 0, 20);
+    position = RayTracer::Point3D(0, 0, -14);
     rotation = RayTracer::Point3D(1, 0, 0);
 }
 

--- a/src/Lights/Spot.cpp
+++ b/src/Lights/Spot.cpp
@@ -12,8 +12,8 @@ Spot::Spot() {
 
 void Spot::Init() {
     angle = 180;
-    intensity = 50.f;
-    position = RayTracer::Point3D(10, 2, 32);
+    intensity = 100.f;
+    position = RayTracer::Point3D(10, 10, 35);
     rotation = RayTracer::Point3D(1, 0, 0);
 }
 

--- a/src/Lights/Spot.cpp
+++ b/src/Lights/Spot.cpp
@@ -12,8 +12,8 @@ Spot::Spot() {
 
 void Spot::Init() {
     angle = 360;
-    intensity = 240.f;
-    position = RayTracer::Point3D(-25, 0, 0);
+    intensity = 140.f;
+    position = RayTracer::Point3D(0, 0, 10);
     rotation = RayTracer::Point3D(1, 0, 0);
 }
 
@@ -21,10 +21,4 @@ float Spot::getLuminescence(float angle, float distance) {
     if (angle > this->angle)
         return 0;
     return intensity / std::pow(distance, 2);
-}
-
-bool Spot::hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) {
-    (void) ray;
-    (void) intersection;
-    return false;
 }

--- a/src/Lights/Spot.hpp
+++ b/src/Lights/Spot.hpp
@@ -7,6 +7,6 @@ class Spot : public RayTracer::A_Lights {
  public:
     Spot();
     void Init() override;
-    float getLuminescence(float angle) override;
+    float getLuminescence(float angle, float distance) override;
     bool hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) override;
 };

--- a/src/Lights/Spot.hpp
+++ b/src/Lights/Spot.hpp
@@ -8,5 +8,4 @@ class Spot : public RayTracer::A_Lights {
     Spot();
     void Init() override;
     float getLuminescence(float angle, float distance) override;
-    bool hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) override;
 };

--- a/src/Lights/Spot.hpp
+++ b/src/Lights/Spot.hpp
@@ -7,6 +7,6 @@ class Spot : public RayTracer::A_Lights {
  public:
     Spot();
     void Init() override;
-    float getLuminescence(float distance, float angle) override;
+    float getLuminescence(float angle) override;
     bool hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) override;
 };

--- a/src/Lights/Spot.hpp
+++ b/src/Lights/Spot.hpp
@@ -7,5 +7,7 @@ class Spot : public RayTracer::A_Lights {
  public:
     Spot();
     void Init() override;
-    float getLuminescence(float angle, float distance) override;
+    float getLuminescence(RayTracer::Point3D intersection,
+        std::shared_ptr<I_Light> Light,
+        std::shared_ptr<I_Primitive> obj) override;
 };

--- a/src/Lights/Spot.hpp
+++ b/src/Lights/Spot.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <memory>
+
 #include "Interfaces/Light/A_Light.hpp"
 #include "3dDatas/Point3D.hpp"
 #include "3dDatas/Ray.hpp"

--- a/src/Primitive/PrimSphere.cpp
+++ b/src/Primitive/PrimSphere.cpp
@@ -3,7 +3,6 @@
 #include "Primitive/PrimSphere.hpp"
 #include "dlLoader/dlLoader.hpp"
 #include "Consts/const.hpp"
-#include "PrimSphere.hpp"
 
 extern "C" std::unique_ptr<RayTracer::I_Primitive> getPrimitive() {
     return std::make_unique<PrimSphere>();
@@ -38,8 +37,7 @@ RayTracer::Vector3D PrimSphere::getNormalAt(RayTracer::Point3D point) {
     return (point - position).normalize();
 }
 
-void PrimSphere::Init()
-{
+void PrimSphere::Init() {
     static int i = -1;
     i++;
 

--- a/src/Primitive/PrimSphere.cpp
+++ b/src/Primitive/PrimSphere.cpp
@@ -26,10 +26,13 @@ bool PrimSphere::hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) {
 
     double t1 = (-b - std::sqrt(discriminant)) / (2.0 * a);
     double t2 = (-b + std::sqrt(discriminant)) / (2.0 * a);
-
-    double t = t1 < t2 ? t1 : t2;
+    double t = (t1 < 0) ?
+        (t2 < 0 ? -1 : t2) :
+        (t2 < 0 ? t1 : std::min(t1, t2));
 
     intersection = ray.origin + ray.direction * t;
+    if (t < 0)
+        return false;
     return true;
 }
 
@@ -42,9 +45,9 @@ void PrimSphere::Init() {
     i++;
 
     if (i == 0)
-        position = RayTracer::Point3D(-12, 0, 30.f);
+        position = RayTracer::Point3D(-11, 0, 30.f);
     else
-        position = RayTracer::Point3D(24, 0, 0);
+        position = RayTracer::Point3D(22, 0, 0);
     radius = 10.f;
 
     try {

--- a/src/Primitive/PrimSphere.cpp
+++ b/src/Primitive/PrimSphere.cpp
@@ -27,10 +27,7 @@ bool PrimSphere::hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) {
     double t1 = (-b - std::sqrt(discriminant)) / (2.0 * a);
     double t2 = (-b + std::sqrt(discriminant)) / (2.0 * a);
 
-    // Vérifiez que t est positif (intersection devant l'origine)
-    double t = (t1 > 0) ? t1 : ((t2 > 0) ? t2 : -1);
-    if (t < 0)
-        return false;
+    double t = t1 < t2 ? t1 : t2;
 
     intersection = ray.origin + ray.direction * t;
     return true;

--- a/src/Primitive/PrimSphere.cpp
+++ b/src/Primitive/PrimSphere.cpp
@@ -26,7 +26,12 @@ bool PrimSphere::hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) {
 
     double t1 = (-b - std::sqrt(discriminant)) / (2.0 * a);
     double t2 = (-b + std::sqrt(discriminant)) / (2.0 * a);
-    double t = (t1 < t2) ? t1 : t2;
+
+    // Vérifiez que t est positif (intersection devant l'origine)
+    double t = (t1 > 0) ? t1 : ((t2 > 0) ? t2 : -1);
+    if (t < 0)
+        return false;
+
     intersection = ray.origin + ray.direction * t;
     return true;
 }
@@ -36,9 +41,9 @@ void PrimSphere::Init() {
     i++;
 
     if (i == 0)
-        position = RayTracer::Point3D(0, 0, 30.f);
+        position = RayTracer::Point3D(-12, 0, 30.f);
     else
-        position = RayTracer::Point3D(5, 5, 5);
+        position = RayTracer::Point3D(24, 0, 0);
     radius = 10.f;
 
     try {

--- a/src/Primitive/PrimSphere.cpp
+++ b/src/Primitive/PrimSphere.cpp
@@ -1,4 +1,5 @@
 #include <memory>
+#include <algorithm>
 
 #include "Primitive/PrimSphere.hpp"
 #include "dlLoader/dlLoader.hpp"

--- a/src/Primitive/PrimSphere.cpp
+++ b/src/Primitive/PrimSphere.cpp
@@ -3,6 +3,7 @@
 #include "Primitive/PrimSphere.hpp"
 #include "dlLoader/dlLoader.hpp"
 #include "Consts/const.hpp"
+#include "PrimSphere.hpp"
 
 extern "C" std::unique_ptr<RayTracer::I_Primitive> getPrimitive() {
     return std::make_unique<PrimSphere>();
@@ -33,7 +34,12 @@ bool PrimSphere::hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) {
     return true;
 }
 
-void PrimSphere::Init() {
+RayTracer::Vector3D PrimSphere::getNormalAt(RayTracer::Point3D point) {
+    return (point - position).normalize();
+}
+
+void PrimSphere::Init()
+{
     static int i = -1;
     i++;
 

--- a/src/Primitive/PrimSphere.hpp
+++ b/src/Primitive/PrimSphere.hpp
@@ -10,5 +10,6 @@ class PrimSphere : public RayTracer::A_Primitive {
     double radius;
     PrimSphere();
     bool hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) override;
+    RayTracer::Vector3D getNormalAt(RayTracer::Point3D point) override;
     void Init() override;
 };

--- a/src/Scene/Scene.hpp
+++ b/src/Scene/Scene.hpp
@@ -11,6 +11,7 @@ class Scene {
     static Scene *i;
 
     std::shared_ptr<I_Primitive> ObjectHead;
+    std::vector<std::shared_ptr<I_Light>> Lights;
 
     Scene();
 };


### PR DESCRIPTION
Add better lighting throw computing with normal vector
Handling multiple lights that are now in the tree of objects
Objects cast shadow on other objects
the back of a object is now not illuminated

### Light Management Enhancements:
* Refactored the `getLuminescence` method in `I_Light` and its derived classes (`Ambient`, `Spot`, `A_Lights`) to include additional parameters for intersection points and associated objects, enabling more precise lighting calculations.
* Introduced a `Lights` vector in the `Scene` class to manage multiple lights dynamically, removing the need for individual light references. 
* Updated the `generateImage` and `hit` functions to utilize the new `Lights` vector for calculating luminescence, replacing the previous single-light approach.

### 3D Geometry Improvements:
* Added `operator==` and `operator!=` to `Point3D` for easier comparison of points.
* Enhanced the `Vector3D::normalize` method to return a reference to the vector, enabling method chaining. 
* Implemented a `getNormalAt` method in `I_Primitive` and its derived classes (`PrimSphere`) to calculate surface normals at specific points for lights

### Code Refactoring:
* Removed the `Light` parameter from the `generateImage` and `checkHitsAtPixel` functions, simplifying their signatures and aligning them with the new light management system. 