### PR TITLE
:sparkles:  primitive none & Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ SRC_TESTS	= 	\
 	tests/test_Point3D.cpp \
 	tests/test_PrimNone.cpp \
 	tests/test_render.cpp \
+	tests/test_computeTreeValues.cpp \
 
 COMMON_SRC = src/3dDatas/Point3D.cpp \
 			src/3dDatas/Vector3D.cpp \

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ SRC_TESTS	= 	\
 	tests/test_Ray.cpp \
 	tests/test_Point3D.cpp \
 	tests/test_PrimNone.cpp \
+	tests/test_render.cpp \
 
 COMMON_SRC = src/3dDatas/Point3D.cpp \
 			src/3dDatas/Vector3D.cpp \

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,8 @@ primitive:
 	@mkdir -p libs
 	$(COMPILER) -olibs/primitive_sphere.so -shared -fPIC $(SRC_PRIMITIVE) \
 		src/Primitive/PrimSphere.cpp $(FLAGS_SO)
+	$(COMPILER) -olibs/primitive_none.so -shared -fPIC $(SRC_PRIMITIVE) \
+		src/Primitive/PrimNone.cpp $(FLAGS_SO)
 
 material:
 	@mkdir -p libs

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ SRC_TESTS	= 	\
 	tests/test_Rectangle3D.cpp \
 	tests/test_Ray.cpp \
 	tests/test_Point3D.cpp \
+	tests/test_PrimNone.cpp \
 
 COMMON_SRC = src/3dDatas/Point3D.cpp \
 			src/3dDatas/Vector3D.cpp \
@@ -144,7 +145,7 @@ run: all
 
 # ============= TESTS ============= #
 
-unit_tests: fclean
+unit_tests: fclean primitive light material
 	@mkdir -p $(OBJ_DIR)
 	$(COMPILER) -o $(OBJ_DIR)/unit_tests $(SRC_TESTS) $(SRC) $(FLAGS_TEST)
 	cp $(OBJ_DIR)/unit_tests unit_tests

--- a/include/Generation/tools.hpp
+++ b/include/Generation/tools.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <memory>
+#include <string>
 
 #include "Interfaces/Primitive/I_Primitive.hpp"
 #include "Consts/const.hpp"

--- a/include/Generation/tools.hpp
+++ b/include/Generation/tools.hpp
@@ -21,3 +21,4 @@ void computeTreeValues(std::shared_ptr<Prim> head,
 // Create Image
 void screenshot(sf::RenderWindow &window);
 void renderAtClosing(sf::RenderWindow &window);
+std::string getTimestampAsString();

--- a/src/Primitive/PrimNone.cpp
+++ b/src/Primitive/PrimNone.cpp
@@ -1,0 +1,31 @@
+#include <memory>
+#include <algorithm>
+
+#include "Primitive/PrimNone.hpp"
+#include "dlLoader/dlLoader.hpp"
+#include "Consts/const.hpp"
+
+extern "C" std::unique_ptr<RayTracer::I_Primitive> getPrimitive() {
+    return std::make_unique<PrimNone>();
+}
+
+PrimNone::PrimNone() {
+    Init();
+}
+
+bool PrimNone::hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) {
+    (void)ray;
+    (void)intersection;
+    return false;
+}
+
+RayTracer::Vector3D PrimNone::getNormalAt(RayTracer::Point3D point) {
+    (void)point;
+    return RayTracer::Vector3D(0,0,0);
+}
+
+void PrimNone::Init() {
+    position = RayTracer::Point3D(0, 0, 0);
+    radius = 0.f;
+    material = nullptr;
+}

--- a/src/Primitive/PrimNone.cpp
+++ b/src/Primitive/PrimNone.cpp
@@ -21,7 +21,7 @@ bool PrimNone::hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) {
 
 RayTracer::Vector3D PrimNone::getNormalAt(RayTracer::Point3D point) {
     (void)point;
-    return RayTracer::Vector3D(0,0,0);
+    return RayTracer::Vector3D(0, 0, 0);
 }
 
 void PrimNone::Init() {

--- a/src/Primitive/PrimNone.hpp
+++ b/src/Primitive/PrimNone.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "Interfaces/Primitive/A_Primitive.hpp"
+#include "3dDatas/Point3D.hpp"
+#include "3dDatas/Vector3D.hpp"
+#include "3dDatas/Ray.hpp"
+
+class PrimNone : public RayTracer::A_Primitive {
+ public:
+    double radius;
+    PrimNone();
+    bool hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) override;
+    RayTracer::Vector3D getNormalAt(RayTracer::Point3D point) override;
+    void Init() override;
+};

--- a/tests/test_PrimNone.cpp
+++ b/tests/test_PrimNone.cpp
@@ -1,11 +1,15 @@
 #include <criterion/criterion.h>
+#include <memory>
+#include <string>
 #include "3dDatas/Point3D.hpp"
 #include "3dDatas/Vector3D.hpp"
 #include "dlLoader/dlLoader.hpp"
 #include "Interfaces/Primitive/I_Primitive.hpp"
 
-static std::shared_ptr<RayTracer::I_Primitive> getPrimitive(std::string libName) {
-    return dlLoader<RayTracer::I_Primitive>::getLib("./libs/" + libName, "getPrimitive");
+static std::shared_ptr<RayTracer::I_Primitive> getPrimitive
+(std::string libName) {
+    return dlLoader<RayTracer::I_Primitive>::getLib("./libs/"
+    + libName, "getPrimitive");
 }
 
 Test(I_Primitive, PrimNone) {

--- a/tests/test_PrimNone.cpp
+++ b/tests/test_PrimNone.cpp
@@ -1,0 +1,57 @@
+#include <criterion/criterion.h>
+#include "3dDatas/Point3D.hpp"
+#include "3dDatas/Vector3D.hpp"
+#include "dlLoader/dlLoader.hpp"
+#include "Interfaces/Primitive/I_Primitive.hpp"
+
+std::shared_ptr<RayTracer::I_Primitive> getPrimitive(std::string libName) {
+    return dlLoader<RayTracer::I_Primitive>::getLib("./libs/" + libName, "getPrimitive");
+}
+
+Test(I_Primitive, PrimNone) {
+    try {
+        std::shared_ptr<RayTracer::I_Primitive> prim =
+            getPrimitive("primitive_none.so");
+        cr_assert_not_null(prim);
+    } catch (std::exception &e) {
+        cr_assert_fail("Failed to load the library or get the primitive");
+    }
+}
+
+Test(I_Primitive, Hits) {
+    try {
+        std::shared_ptr<RayTracer::I_Primitive> prim =
+            getPrimitive("primitive_none.so");
+        prim->Init();
+        RayTracer::Ray ray;
+        RayTracer::Point3D p(0, 0, 0);
+        cr_assert(prim->hits(ray, p) == false);
+        p.z = 1;
+        ray.direction = RayTracer::Vector3D(0, 0, 1);
+        cr_assert(prim->hits(ray, p) == false);
+    } catch (std::exception &e) {
+        cr_assert_fail("Failed to load the library or get the primitive");
+    }
+}
+
+Test(I_Primitive, GetNormalAt) {
+    try {
+        std::shared_ptr<RayTracer::I_Primitive> prim =
+            getPrimitive("primitive_none.so");
+        prim->Init();
+        RayTracer::Ray ray;
+        RayTracer::Point3D p(0, 0, 0);
+        RayTracer::Vector3D norm = prim->getNormalAt(p);
+        cr_assert_eq(norm.x, 0);
+        cr_assert_eq(norm.y, 0);
+        cr_assert_eq(norm.z, 0);
+        p.z = 1;
+        ray.direction = RayTracer::Vector3D(0, 0, 1);
+        norm = prim->getNormalAt(p);
+        cr_assert_eq(norm.x, 0);
+        cr_assert_eq(norm.y, 0);
+        cr_assert_eq(norm.z, 0);
+    } catch (std::exception &e) {
+        cr_assert_fail("Failed to load the library or get the primitive");
+    }
+}

--- a/tests/test_PrimNone.cpp
+++ b/tests/test_PrimNone.cpp
@@ -4,7 +4,7 @@
 #include "dlLoader/dlLoader.hpp"
 #include "Interfaces/Primitive/I_Primitive.hpp"
 
-std::shared_ptr<RayTracer::I_Primitive> getPrimitive(std::string libName) {
+static std::shared_ptr<RayTracer::I_Primitive> getPrimitive(std::string libName) {
     return dlLoader<RayTracer::I_Primitive>::getLib("./libs/" + libName, "getPrimitive");
 }
 

--- a/tests/test_computeTreeValues.cpp
+++ b/tests/test_computeTreeValues.cpp
@@ -1,13 +1,16 @@
 #include <criterion/criterion.h>
 #include <memory>
+#include <string>
 
 #include "Scene/Scene.hpp"
 #include "Lights/Spot.hpp"
 #include "Generation/tools.hpp"
 #include "dlLoader/dlLoader.hpp"
 
-static std::shared_ptr<RayTracer::I_Primitive> getPrimitive(std::string libName) {
-    return dlLoader<RayTracer::I_Primitive>::getLib("./libs/" + libName, "getPrimitive");
+static std::shared_ptr<RayTracer::I_Primitive> getPrimitive
+(std::string libName) {
+    return dlLoader<RayTracer::I_Primitive>::getLib("./libs/"
+    + libName, "getPrimitive");
 }
 
 Test(ComputeTreeValues, update_positions) {
@@ -24,7 +27,10 @@ Test(ComputeTreeValues, update_positions) {
 
     computeTreeValues(parent);
 
-    cr_assert_eq(child->getPosition().x, posOriginal.x + 10, "Child X position incorrect : %f", child->getPosition().x);
-    cr_assert_eq(child->getPosition().y, posOriginal.y + 10, "Child Y position incorrect : %f", child->getPosition().y);
-    cr_assert_eq(child->getPosition().z, posOriginal.z + 10, "Child Z position incorrect : %f", child->getPosition().z);
+    cr_assert_eq(child->getPosition().x, posOriginal.x + 10,
+        "Child X position incorrect : %f", child->getPosition().x);
+    cr_assert_eq(child->getPosition().y, posOriginal.y + 10,
+        "Child Y position incorrect : %f", child->getPosition().y);
+    cr_assert_eq(child->getPosition().z, posOriginal.z + 10,
+        "Child Z position incorrect : %f", child->getPosition().z);
 }

--- a/tests/test_computeTreeValues.cpp
+++ b/tests/test_computeTreeValues.cpp
@@ -1,0 +1,30 @@
+#include <criterion/criterion.h>
+#include <memory>
+
+#include "Scene/Scene.hpp"
+#include "Lights/Spot.hpp"
+#include "Generation/tools.hpp"
+#include "dlLoader/dlLoader.hpp"
+
+static std::shared_ptr<RayTracer::I_Primitive> getPrimitive(std::string libName) {
+    return dlLoader<RayTracer::I_Primitive>::getLib("./libs/" + libName, "getPrimitive");
+}
+
+Test(ComputeTreeValues, update_positions) {
+    RayTracer::Scene scene;
+    RayTracer::Scene::i = &scene;
+    RayTracer::Point3D posOriginal;
+
+    auto parent = getPrimitive("primitive_sphere.so");
+    parent->setPosition(RayTracer::Point3D(10, 10, 10));
+
+    auto child = getPrimitive("primitive_sphere.so");
+    parent->AddChildren(child);
+    posOriginal = child->getPosition();
+
+    computeTreeValues(parent);
+
+    cr_assert_eq(child->getPosition().x, posOriginal.x + 10, "Child X position incorrect : %f", child->getPosition().x);
+    cr_assert_eq(child->getPosition().y, posOriginal.y + 10, "Child Y position incorrect : %f", child->getPosition().y);
+    cr_assert_eq(child->getPosition().z, posOriginal.z + 10, "Child Z position incorrect : %f", child->getPosition().z);
+}

--- a/tests/test_render.cpp
+++ b/tests/test_render.cpp
@@ -1,0 +1,35 @@
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
+#include <memory>
+#include <fstream>
+#include <filesystem>
+#include <SFML/Graphics.hpp>
+#include <SFML/Window.hpp>
+#include <SFML/System.hpp>
+
+#include "Generation/tools.hpp"
+
+void redirect_all_stdout() {
+    cr_redirect_stdout();
+    cr_redirect_stderr();
+}
+
+Test(Render, render_at_closing, .init = redirect_all_stdout) {
+    sf::RenderWindow window(sf::VideoMode(10, 10), "Test Render");
+    std::string filename = "renders/render-" + getTimestampAsString() + ".ppm";
+
+    renderAtClosing(window);
+
+    cr_assert(std::filesystem::exists(filename), "Render file was not created.");
+    std::filesystem::remove(filename);  // Clean up
+}
+
+Test(Render, screenshot, .init = redirect_all_stdout) {
+    sf::RenderWindow window(sf::VideoMode(10, 10), "Test Screenshot");
+    std::string filename = "renders/screenshot-" + getTimestampAsString() + ".ppm";
+
+    screenshot(window);
+
+    cr_assert(std::filesystem::exists(filename), "Screenshot file was not created.");
+    std::filesystem::remove(filename);  // Clean up
+}

--- a/tests/test_render.cpp
+++ b/tests/test_render.cpp
@@ -1,8 +1,11 @@
 #include <criterion/criterion.h>
 #include <criterion/redirect.h>
+
 #include <memory>
 #include <fstream>
 #include <filesystem>
+#include <string>
+
 #include <SFML/Graphics.hpp>
 #include <SFML/Window.hpp>
 #include <SFML/System.hpp>
@@ -20,16 +23,19 @@ Test(Render, render_at_closing, .init = redirect_all_stdout) {
 
     renderAtClosing(window);
 
-    cr_assert(std::filesystem::exists(filename), "Render file was not created.");
+    cr_assert(std::filesystem::exists(filename),
+        "Render file was not created.");
     std::filesystem::remove(filename);  // Clean up
 }
 
 Test(Render, screenshot, .init = redirect_all_stdout) {
     sf::RenderWindow window(sf::VideoMode(10, 10), "Test Screenshot");
-    std::string filename = "renders/screenshot-" + getTimestampAsString() + ".ppm";
+    std::string filename = "renders/screenshot-" + getTimestampAsString()
+        + ".ppm";
 
     screenshot(window);
 
-    cr_assert(std::filesystem::exists(filename), "Screenshot file was not created.");
+    cr_assert(std::filesystem::exists(filename),
+        "Screenshot file was not created.");
     std::filesystem::remove(filename);  // Clean up
 }


### PR DESCRIPTION
This pull request introduces a new primitive type (`PrimNone`) to the RayTracer project, along with supporting changes to the build system, tests, and utilities. The most important changes include the implementation of the `PrimNone` class, updates to the `Makefile` to integrate the new primitive, and the addition of unit tests for the new functionality and related utilities.

### New Primitive Implementation:
* Added the `PrimNone` class in `src/Primitive/PrimNone.cpp` and its header in `src/Primitive/PrimNone.hpp`. This class represents a primitive that does not interact with rays (always returns no hits) and has a default position and radius.

### Build System Updates:
* Updated the `Makefile` to include the new `PrimNone` primitive in the build process and added it to the shared library compilation step.
* Modified the `unit_tests` target in the `Makefile` to ensure required libraries (e.g., `primitive`, `light`, `material`) are built before running tests.

### Unit Tests:
* Added `tests/test_PrimNone.cpp` to test the functionality of the `PrimNone` primitive, including its `hits` and `getNormalAt` methods.
* Added `tests/test_computeTreeValues.cpp` to test the `computeTreeValues` function, ensuring child positions are updated correctly based on the parent primitive.
* Added `tests/test_render.cpp` to test rendering utilities like `screenshot` and `renderAtClosing`, ensuring output files are created as expected.

### Utility Enhancements:
* Declared a new utility function `getTimestampAsString` in `include/Generation/tools.hpp` to generate timestamp-based filenames for rendering and screenshots.