### PR TITLE
:sparkles: primitive cylinder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,11 @@ sphere:
 	$(COMPILER) -olibs/primitive_sphere.so -shared -fPIC $(SRC_PRIMITIVE) \
 		src/Primitive/PrimSphere.cpp $(FLAGS_SO)
 
+cylinder:
+	@mkdir -p libs
+	$(COMPILER) -olibs/primitive_cylinder.so -shared -fPIC $(SRC_PRIMITIVE) \
+		src/Primitive/PrimCylinder.cpp $(FLAGS_SO)
+
 plane:
 	@mkdir -p libs
 	$(COMPILER) -olibs/primitive_plane.so -shared -fPIC $(SRC_PRIMITIVE) \

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,8 @@ FLAGS_LINTER =	\
 	--quiet \
 	--output=vs7	\
 	--filter=-legal/copyright,-build/c++17,+build/c++20,-runtime/references\
-	--recursive
+	--recursive \
+	--exclude=tests/ \
 
 FLAGS_SO = $(FLAGS_LIB) -lsfml-graphics -lsfml-window -lsfml-system \
             $(FLAGS_INCLUDE) -ldl -g \
@@ -73,6 +74,7 @@ SRC_TESTS	= 	\
 	tests/test_computeTreeValues.cpp \
 	tests/test_LoadSo.cpp \
 	tests/test_A_Primitive.cpp \
+	tests/test_A_Light.cpp \
 
 COMMON_SRC = src/3dDatas/Point3D.cpp \
 			src/3dDatas/Vector3D.cpp \

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,8 @@ SRC_TESTS	= 	\
 	tests/test_Point3D.cpp \
 	tests/test_PrimNone.cpp \
 	tests/test_computeTreeValues.cpp \
+	tests/test_LoadSo.cpp \
+	tests/test_A_Primitive.cpp \
 
 COMMON_SRC = src/3dDatas/Point3D.cpp \
 			src/3dDatas/Vector3D.cpp \
@@ -114,7 +116,7 @@ none:
 	$(COMPILER) -olibs/primitive_none.so -shared -fPIC $(SRC_PRIMITIVE) \
 		src/Primitive/PrimNone.cpp $(FLAGS_SO)
 
-primitive: sphere plane none
+primitive: sphere plane none cylinder
 
 flat_mat:
 	@mkdir -p libs

--- a/main.cpp
+++ b/main.cpp
@@ -27,11 +27,9 @@ static void setupAndRun(sf::RenderWindow &window, sf::Image &image) {
        "./libs/light_ambient.so", "getLight"));
 
     RayTracer::Scene::i->ObjectHead->AddChildren(
-        dlLoader<Prim>::getLib("./libs/primitive_sphere.so", "getPrimitive"));
-    RayTracer::Scene::i->ObjectHead->AddChildren(
-        dlLoader<Prim>::getLib("./libs/primitive_sphere.so", "getPrimitive"));
-    RayTracer::Scene::i->ObjectHead->AddChildren(
         dlLoader<Prim>::getLib("./libs/primitive_plane.so", "getPrimitive"));
+    RayTracer::Scene::i->ObjectHead->AddChildren(
+        dlLoader<Prim>::getLib("./libs/primitive_cylinder.so", "getPrimitive"));
     RayTracer::Scene::i->ObjectHead->AddChildren(
         dlLoader<Prim>::getLib("./libs/light_spot.so", "getLight"));
 

--- a/src/Lights/Spot.hpp
+++ b/src/Lights/Spot.hpp
@@ -14,5 +14,6 @@ class Spot : public RayTracer::A_Lights {
         std::shared_ptr<I_Primitive> obj,
         std::shared_ptr<I_Primitive> head) override;
     bool checkBlockingLight(std::shared_ptr<RayTracer::I_Primitive> &obj,
-        std::shared_ptr<RayTracer::I_Primitive> &head, RayTracer::Ray &r);
+        std::shared_ptr<RayTracer::I_Primitive> &head, RayTracer::Ray &r,
+        float distLight);
 };

--- a/src/Primitive/PrimCylinder.cpp
+++ b/src/Primitive/PrimCylinder.cpp
@@ -23,16 +23,15 @@ bool PrimCylinder::hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) {
     float C = deltaPPerp.dot(deltaPPerp) - radius * radius;
 
     float d = B * B - 4.0f * A * C;
-
+    if (d < 0)
+        return false;
     float t1 = (-B - std::sqrt(d)) / (2 * A);
     float t2 = (-B + std::sqrt(d)) / (2 * A);
     float t = (t1 < t2) ? t1 : t2;
     if (t < 0)
         return false;
     intersection = ray.origin + ray.direction * t;
-    if (d >= 0)
-        return true;
-    return false;
+    return true;
 }
 
 RayTracer::Vector3D PrimCylinder::getNormalAt(RayTracer::Point3D point) {

--- a/src/Primitive/PrimCylinder.cpp
+++ b/src/Primitive/PrimCylinder.cpp
@@ -1,0 +1,62 @@
+#include <memory>
+#include <algorithm>
+
+#include "Primitive/PrimCylinder.hpp"
+#include "dlLoader/dlLoader.hpp"
+#include "Consts/const.hpp"
+
+extern "C" std::unique_ptr<RayTracer::I_Primitive> getPrimitive() {
+    return std::make_unique<PrimCylinder>();
+}
+
+PrimCylinder::PrimCylinder() {
+    Init();
+}
+
+bool PrimCylinder::hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) {
+    RayTracer::Vector3D deltaP = ray.origin - position;
+    RayTracer::Vector3D vPerp = ray.direction - va * ray.direction.dot(va);
+    RayTracer::Vector3D deltaPPerp = deltaP - va * deltaP.dot(va);
+
+    float A = vPerp.dot(vPerp);
+    float B = 2.0f * vPerp.dot(deltaPPerp);
+    float C = deltaPPerp.dot(deltaPPerp) - radius * radius;
+
+    float d = B * B - 4.0f * A * C;
+
+    float t1 = (-B - std::sqrt(d)) / (2 * A);
+    float t2 = (-B + std::sqrt(d)) / (2 * A);
+    float t = (t1 < t2) ? t1 : t2;
+    if (t < 0)
+        return false;
+    intersection = ray.origin + ray.direction * t;
+    if (d >= 0)
+        return true;
+    return false;
+}
+
+RayTracer::Vector3D PrimCylinder::getNormalAt(RayTracer::Point3D point) {
+    RayTracer::Point3D posUpdated = position;
+    posUpdated.y = point.y;
+    return (point - posUpdated).normalize();
+}
+
+void PrimCylinder::Init() {
+    static int i = 0;
+
+    va = RayTracer::Vector3D(0, 1, 0);
+    if (i == 0) {
+        position = RayTracer::Point3D(0, -1, 5);
+        radius = 0.1f;
+    } else {
+        position = RayTracer::Point3D(0, .1f, 5);
+        radius = 0.2f;
+    }
+    i++;
+
+    try {
+        material = dlLoader<Mat>::getLib("libs/mat_flat.so", "getMaterial");
+    } catch (std::exception &e) {
+        material = nullptr;
+    }
+}

--- a/src/Primitive/PrimCylinder.hpp
+++ b/src/Primitive/PrimCylinder.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "Interfaces/Primitive/A_Primitive.hpp"
+#include "3dDatas/Point3D.hpp"
+#include "3dDatas/Vector3D.hpp"
+#include "3dDatas/Ray.hpp"
+
+class PrimCylinder : public RayTracer::A_Primitive {
+ public:
+    double radius;
+    RayTracer::Vector3D va;
+    PrimCylinder();
+    bool hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) override;
+    RayTracer::Vector3D getNormalAt(RayTracer::Point3D point) override;
+    void Init() override;
+};

--- a/src/Primitive/PrimPlane.cpp
+++ b/src/Primitive/PrimPlane.cpp
@@ -20,11 +20,10 @@ PrimPlane::PrimPlane() {
 }
 
 bool PrimPlane::hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) {
-    RayTracer::Vector3D deltaP = ray.origin - position;
-    float denom = normal.dot(ray.direction);
-
-    if (std::abs(denom) > 1e-6f) {
-        float t = -normal.dot(deltaP) / denom;
+    double denom = normal.dot(ray.direction);
+    if (std::abs(denom) > 1e-6) {
+        RayTracer::Vector3D p0l0 = position - ray.origin;
+        double t = p0l0.dot(normal) / denom;
         if (t >= 0) {
             intersection = ray.origin + ray.direction * t;
             return true;

--- a/src/Primitive/PrimPlane.cpp
+++ b/src/Primitive/PrimPlane.cpp
@@ -20,10 +20,11 @@ PrimPlane::PrimPlane() {
 }
 
 bool PrimPlane::hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) {
-    double denom = normal.dot(ray.direction);
-    if (std::abs(denom) > 1e-6) {
-        RayTracer::Vector3D p0l0 = position - ray.origin;
-        double t = p0l0.dot(normal) / denom;
+    RayTracer::Vector3D deltaP = ray.origin - position;
+    float denom = normal.dot(ray.direction);
+
+    if (std::abs(denom) > 1e-6f) {
+        float t = -normal.dot(deltaP) / denom;
         if (t >= 0) {
             intersection = ray.origin + ray.direction * t;
             return true;
@@ -38,7 +39,7 @@ RayTracer::Vector3D PrimPlane::getNormalAt(RayTracer::Point3D point) {
 }
 
 void PrimPlane::Init() {
-    position = RayTracer::Point3D(0, 0.5f, 0);
+    position = RayTracer::Point3D(0, 1, 0);
     normal = RayTracer::Vector3D(0, -1, 0);
     radius = 10.f;
 

--- a/src/Primitive/PrimSphere.cpp
+++ b/src/Primitive/PrimSphere.cpp
@@ -45,7 +45,7 @@ void PrimSphere::Init() {
     static int i = 0;
 
     if (i == 0) {
-        position = RayTracer::Point3D(0, -1, 5);
+        position = RayTracer::Point3D(0, -4, 5);
         radius = 1.f;
     } else {
         position = RayTracer::Point3D(0, .1f, 5);

--- a/tests/test_A_Light.cpp
+++ b/tests/test_A_Light.cpp
@@ -1,0 +1,49 @@
+#include <criterion/criterion.h>
+#include <memory>
+#include "Interfaces/Light/A_Light.hpp"
+#include "3dDatas/Point3D.hpp"
+#include "3dDatas/Vector3D.hpp"
+
+class TestLight : public RayTracer::A_Lights {
+ public:
+    float getLuminescence(RayTracer::Point3D intersection,
+        std::shared_ptr<I_Light> Light, std::shared_ptr<I_Primitive> obj,
+        std::shared_ptr<I_Primitive> head) override {
+        (void)intersection;
+        (void)Light;
+        (void)obj;
+        (void)head;
+        return intensity;
+    }
+    void Init() override {}
+};
+
+Test(A_Light, SetAndGetPosition) {
+    std::shared_ptr<RayTracer::A_Lights> light = std::make_shared<TestLight>();
+    RayTracer::Point3D position(1, 2, 3);
+
+    light->setPosition(position);
+    cr_assert_eq(light->getPosition().x, 1);
+    cr_assert_eq(light->getPosition().y, 2);
+    cr_assert_eq(light->getPosition().z, 3);
+}
+
+Test(A_Light, SetAndGetRotation) {
+    std::shared_ptr<RayTracer::A_Lights> light = std::make_shared<TestLight>();
+    RayTracer::Point3D rotation(10, 20, 30);
+
+    light->setRotation(rotation);
+    cr_assert_eq(light->getRotation().x, 10);
+    cr_assert_eq(light->getRotation().y, 20);
+    cr_assert_eq(light->getRotation().z, 30);
+}
+
+Test(A_Light, SetAndGetScale) {
+    std::shared_ptr<RayTracer::A_Lights> light = std::make_shared<TestLight>();
+    RayTracer::Point3D scale(2, 2, 2);
+
+    light->setScale(scale);
+    cr_assert_eq(light->getScale().x, 2);
+    cr_assert_eq(light->getScale().y, 2);
+    cr_assert_eq(light->getScale().z, 2);
+}

--- a/tests/test_A_Primitive.cpp
+++ b/tests/test_A_Primitive.cpp
@@ -1,0 +1,67 @@
+#include <criterion/criterion.h>
+#include <memory>
+#include "Interfaces/Primitive/A_Primitive.hpp"
+#include "3dDatas/Point3D.hpp"
+#include "3dDatas/Vector3D.hpp"
+
+class TestPrimitive : public RayTracer::A_Primitive {
+ public:
+    bool hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) override {
+        (void)ray;
+        (void)intersection;
+        return false;
+    }
+    RayTracer::Vector3D getNormalAt(RayTracer::Point3D point) override {
+        (void)point;
+        return RayTracer::Vector3D(0, 0, 0);
+    }
+    void Init() override {}
+};
+
+Test(A_Primitive, AddChildren) {
+    std::shared_ptr<RayTracer::A_Primitive> parent = std::make_shared<TestPrimitive>();
+    std::shared_ptr<RayTracer::A_Primitive> child = std::make_shared<TestPrimitive>();
+
+    parent->AddChildren(child);
+    cr_assert_eq(parent->getChildrens().size(), 1);
+    cr_assert_eq(parent->getChildrens()[0], child);
+}
+
+Test(A_Primitive, SetAndGetMaterial) {
+    std::shared_ptr<RayTracer::A_Primitive> primitive = std::make_shared<TestPrimitive>();
+    std::shared_ptr<RayTracer::I_Material> material = nullptr;
+
+    cr_assert_throw(primitive->getMaterial(), RayTracer::A_Primitive::PrimitiveError);
+    primitive->setMaterial(material);
+    cr_assert_throw(primitive->getMaterial(), RayTracer::A_Primitive::PrimitiveError);
+}
+
+Test(A_Primitive, SetAndGetPosition) {
+    std::shared_ptr<RayTracer::A_Primitive> primitive = std::make_shared<TestPrimitive>();
+    RayTracer::Point3D position(1, 2, 3);
+
+    primitive->setPosition(position);
+    cr_assert_eq(primitive->getPosition().x, 1);
+    cr_assert_eq(primitive->getPosition().y, 2);
+    cr_assert_eq(primitive->getPosition().z, 3);
+}
+
+Test(A_Primitive, SetAndGetRotation) {
+    std::shared_ptr<RayTracer::A_Primitive> primitive = std::make_shared<TestPrimitive>();
+    RayTracer::Point3D rotation(10, 20, 30);
+
+    primitive->setRotation(rotation);
+    cr_assert_eq(primitive->getRotation().x, 10);
+    cr_assert_eq(primitive->getRotation().y, 20);
+    cr_assert_eq(primitive->getRotation().z, 30);
+}
+
+Test(A_Primitive, SetAndGetScale) {
+    std::shared_ptr<RayTracer::A_Primitive> primitive = std::make_shared<TestPrimitive>();
+    RayTracer::Point3D scale(2, 2, 2);
+
+    primitive->setScale(scale);
+    cr_assert_eq(primitive->getScale().x, 2);
+    cr_assert_eq(primitive->getScale().y, 2);
+    cr_assert_eq(primitive->getScale().z, 2);
+}

--- a/tests/test_LoadSo.cpp
+++ b/tests/test_LoadSo.cpp
@@ -1,0 +1,84 @@
+#include <criterion/criterion.h>
+#include <memory>
+#include <string>
+#include "3dDatas/Point3D.hpp"
+#include "3dDatas/Vector3D.hpp"
+#include "dlLoader/dlLoader.hpp"
+#include "Interfaces/Primitive/I_Primitive.hpp"
+#include "Interfaces/Material/I_Material.hpp"
+#include "Interfaces/Light/I_Light.hpp"
+
+static std::shared_ptr<RayTracer::I_Primitive> getPrimitive(std::string libName) {
+    return dlLoader<RayTracer::I_Primitive>::getLib("./libs/" + libName, "getPrimitive");
+}
+
+static std::shared_ptr<RayTracer::I_Material> getMaterial(std::string libName) {
+    return dlLoader<RayTracer::I_Material>::getLib("./libs/" + libName, "getMaterial");
+}
+
+static std::shared_ptr<RayTracer::I_Light> getLight(std::string libName) {
+    return dlLoader<RayTracer::I_Light>::getLib("./libs/" + libName, "getLight");
+}
+
+Test(LoadSo, PrimitiveSphere) {
+    try {
+        std::shared_ptr<RayTracer::I_Primitive> prim = getPrimitive("primitive_sphere.so");
+        cr_assert_not_null(prim);
+    } catch (std::exception &e) {
+        cr_assert_fail("Failed to load primitive_sphere.so");
+    }
+}
+
+Test(LoadSo, PrimitiveCylinder) {
+    try {
+        std::shared_ptr<RayTracer::I_Primitive> prim = getPrimitive("primitive_cylinder.so");
+        cr_assert_not_null(prim);
+    } catch (std::exception &e) {
+        cr_assert_fail("Failed to load primitive_cylinder.so");
+    }
+}
+
+Test(LoadSo, PrimitivePlane) {
+    try {
+        std::shared_ptr<RayTracer::I_Primitive> prim = getPrimitive("primitive_plane.so");
+        cr_assert_not_null(prim);
+    } catch (std::exception &e) {
+        cr_assert_fail("Failed to load primitive_plane.so");
+    }
+}
+
+Test(LoadSo, PrimitiveNone) {
+    try {
+        std::shared_ptr<RayTracer::I_Primitive> prim = getPrimitive("primitive_none.so");
+        cr_assert_not_null(prim);
+    } catch (std::exception &e) {
+        cr_assert_fail("Failed to load primitive_none.so");
+    }
+}
+
+Test(LoadSo, MaterialFlat) {
+    try {
+        std::shared_ptr<RayTracer::I_Material> mat = getMaterial("mat_flat.so");
+        cr_assert_not_null(mat);
+    } catch (std::exception &e) {
+        cr_assert_fail("Failed to load mat_flat.so");
+    }
+}
+
+Test(LoadSo, LightAmbient) {
+    try {
+        std::shared_ptr<RayTracer::I_Light> light = getLight("light_ambient.so");
+        cr_assert_not_null(light);
+    } catch (std::exception &e) {
+        cr_assert_fail("Failed to load light_ambient.so");
+    }
+}
+
+Test(LoadSo, LightSpot) {
+    try {
+        std::shared_ptr<RayTracer::I_Light> light = getLight("light_spot.so");
+        cr_assert_not_null(light);
+    } catch (std::exception &e) {
+        cr_assert_fail("Failed to load light_spot.so");
+    }
+}


### PR DESCRIPTION
This pull request introduces significant updates, including the addition of a new primitive (`PrimCylinder`) and fix Lightning problem when object is at a greater distance than light it still block the light

### New Primitive Addition:
* Added a new `PrimCylinder` class to represent cylindrical primitives, including its implementation (`hits`, `getNormalAt`, and `Init` methods) in `src/Primitive/PrimCylinder.cpp` and its header file in `src/Primitive/PrimCylinder.hpp`. This includes support for ray intersection and normal calculations.
* Updated the `Makefile` to include a new build target for `primitive_cylinder.so`.

### Lighting Enhancements:
* Updated the `Spot` light class to include a `distLight` parameter in the `checkBlockingLight` method, improving the accuracy of light-blocking calculations by considering the distance to the light source. 