### PR TITLE
:sparkles: Add image preview generation functionality

### DIFF
--- a/include/Generation/tools.hpp
+++ b/include/Generation/tools.hpp
@@ -13,6 +13,7 @@
 // Create Image
 int generateImage(sf::RenderWindow &window, my_Image &image, std::string
     sceneFile);
+int generateImagePreview(sf::RenderWindow &window, my_Image &image, int pixels);
 
 // Render image
 int displayImage(sf::RenderWindow &window, my_Image &image, std::string

--- a/main.cpp
+++ b/main.cpp
@@ -58,7 +58,6 @@ static int setupAndRun(sf::RenderWindow &window, my_Image &image,
     computeTreeValues(RayTracer::Scene::i->ObjectHead);
     for (int i = WIDTH /2; i >= 8; i /= 2)
         generateImagePreview(window, image, i);
-    printf("END FIRST DRAW\n");
     return generateImage(window, image, sceneFile);
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -16,6 +16,7 @@
 #include "dlLoader/dlLoader.hpp"
 #include "Parsing/Parsing.hpp"
 #include "Scene/Scene.hpp"
+#include "Scene/Camera.hpp"
 #include "DesignPatterns/Factory.hpp"
 
 #include <SFML/Graphics.hpp>
@@ -77,6 +78,7 @@ int testMain(std::string sceneFile) {
 int main(int argc, char **argv) {
     RayTracer::Parsing parser;
     int hasFileChanged = 2;
+    RayTracer::Camera cam;
     srand(time(NULL));
 
     while (hasFileChanged != 0) {

--- a/main.cpp
+++ b/main.cpp
@@ -51,6 +51,9 @@ static int setupAndRun(sf::RenderWindow &window, my_Image &image,
         create("sphere"));
 
     computeTreeValues(RayTracer::Scene::i->ObjectHead);
+    for (int i = WIDTH /2; i >= 8; i /= 2)
+        generateImagePreview(window, image, i);
+    printf("END FIRST DRAW\n");
     return generateImage(window, image, sceneFile);
 }
 

--- a/src/Draw/draw.cpp
+++ b/src/Draw/draw.cpp
@@ -121,7 +121,6 @@ my_Image &image, std::vector<std::unique_ptr<my_Image>> &images) {
 
 int generateImage(sf::RenderWindow &window, my_Image &image, std::string
     sceneFile) {
-    RayTracer::Camera cam;
     std::vector<std::thread> threadVector;
     std::vector<std::unique_ptr<my_Image>> images;
     int configChanged = 0;
@@ -130,7 +129,8 @@ int generateImage(sf::RenderWindow &window, my_Image &image, std::string
     createListImages(images, image);
     for (float i = 0; i < WIDTH; i++) {
         threadVector.emplace_back(generatePixelColumn, i,
-            std::ref(cam), std::ref(image), std::ref(images));
+            std::ref(RayTracer::Camera::i()),
+            std::ref(image), std::ref(images));
     }
 
     configChanged = displayImage(window, image, sceneFile);

--- a/src/Draw/drawPreview.cpp
+++ b/src/Draw/drawPreview.cpp
@@ -8,6 +8,8 @@
 #include <thread>
 #include <mutex>
 #include <vector>
+#include <condition_variable>
+#include <queue>
 
 #include <SFML/Graphics.hpp>
 #include <SFML/Window.hpp>
@@ -22,8 +24,6 @@
 #include "Generation/tools.hpp"
 #include "Draw/my_Image.hpp"
 #include "Draw/hit.hpp"
-#include <condition_variable>
-#include <queue>
 
 int sizePixelPreview = 16;
 

--- a/src/Draw/drawPreview.cpp
+++ b/src/Draw/drawPreview.cpp
@@ -122,7 +122,8 @@ my_Image &image) {
     }
 }
 
-int generateImagePreview(sf::RenderWindow &window, my_Image &image, int pixels) {
+int generateImagePreview(sf::RenderWindow &window, my_Image &image,
+int pixels) {
     sizePixelPreview = pixels;
     RayTracer::Camera cam;
     std::vector<std::thread> threadVector;

--- a/src/Draw/drawPreview.cpp
+++ b/src/Draw/drawPreview.cpp
@@ -125,7 +125,6 @@ my_Image &image) {
 int generateImagePreview(sf::RenderWindow &window, my_Image &image,
 int pixels) {
     sizePixelPreview = pixels;
-    RayTracer::Camera cam;
     std::vector<std::thread> threadVector;
     int configChanged = 0;
 
@@ -133,7 +132,7 @@ int pixels) {
     image.image.create(WIDTH, HEIGHT, sf::Color::Black);
     for (float i = 0; i < WIDTH; i += sizePixelPreview) {
         threadVector.emplace_back(generatePixelColumn, i,
-            std::ref(cam), std::ref(image));
+            std::ref(RayTracer::Camera::i()), std::ref(image));
     }
 
     for (auto &t : threadVector) {

--- a/src/Primitive/PrimPlane.cpp
+++ b/src/Primitive/PrimPlane.cpp
@@ -44,7 +44,7 @@ void PrimPlane::Init() {
     radius = 1.f;
 
     try {
-        material = dlLoader<Mat>::getLib("plugins/mat_perlin.so", "getMaterial");
+        material = Factory<RayTracer::I_Material>::i().create("perlin");
     } catch (std::exception &e) {
         material = nullptr;
     }

--- a/src/Primitive/PrimSphere.cpp
+++ b/src/Primitive/PrimSphere.cpp
@@ -56,10 +56,4 @@ void PrimSphere::Init() {
         material = Factory<Mat>::i().create("image");
     }
     j++;
-
-    //try {
-    //    material = Factory<Mat>::i().create("chess");
-    //} catch (std::exception &e) {
-    //    material = nullptr;
-    //}
 }

--- a/src/Scene/Camera.hpp
+++ b/src/Scene/Camera.hpp
@@ -15,6 +15,10 @@ class Camera {
     Point3D lookingAt;
     Matrix4x4 camera_to_world;  // 4x4 transformation matrix
  public:
+    static Camera &i() {
+        static Camera instance;
+        return instance;
+    }
     Point3D origin;
     Rectangle3D screen;
 


### PR DESCRIPTION
This pull request introduces functionality for generating and displaying a lower-resolution preview of an image before rendering the final high-resolution version.

### New Feature: Image Preview Generation
* Added a new function `generateImagePreview` in `tools.hpp` to generate a lower-resolution preview of the image. This function is implemented in a new file, `drawPreview.cpp`, which includes the logic for rendering image previews using multi-threading and pixel grouping. 

### Integration of Preview in Rendering Pipeline
* Updated the rendering pipeline in `main.cpp` to call the new `generateImagePreview` function iteratively with decreasing resolutions before rendering the final image. This provides a progressive rendering experience.

### Code Refactoring
* Refactored the `computeLuminescence` function to be `static` and moved a duplicate implementation into `drawPreview.cpp` for better modularity and to avoid redundancy.