### PR TITLE
:bug: fix rotation of plane

### DIFF
--- a/include/Consts/const.hpp
+++ b/include/Consts/const.hpp
@@ -3,8 +3,8 @@
 #include "Interfaces/Material/I_Material.hpp"
 #include "Interfaces/Light/I_Light.hpp"
 
-const int WIDTH = 2880;
-const int HEIGHT = 1620;
+const int WIDTH = 1280;
+const int HEIGHT = 1080;
 
 typedef RayTracer::I_Primitive Prim;
 typedef RayTracer::I_Material Mat;

--- a/src/Parsing/Parsing.cpp
+++ b/src/Parsing/Parsing.cpp
@@ -77,11 +77,31 @@ void Parsing::parseSceneFile() {
             Factory<Prim>::i().create("plane");
         std::unordered_map<std::string, std::any> planeSettings;
         planeSettings["position"] = std::make_any<Point3D>(Point3D(0, 0, 0));
-        planeSettings["rotation"] = std::make_any<Vector3D>(Vector3D(0, 1, 0));
+        planeSettings["rotation"] = std::make_any<Vector3D>(Vector3D(0, 0, 0));
         planeSettings["radius"] = std::make_any<float>(10.0);
         planeSettings["material"] = std::make_any<std::shared_ptr<Mat>>(mat);
         plane->Init(planeSettings);
         Scene::i->ObjectHead->AddChildren(plane);
+
+        std::shared_ptr<Mat> chess =
+            Factory<Mat>::i().create("chess");
+        std::unordered_map<std::string, std::any> chessSettings;
+        chessSettings["col1"] = std::make_any<sf::Color>(sf::Color(
+            255, 255, 255));
+        chessSettings["col2"] = std::make_any<sf::Color>(sf::Color(0, 0, 0));
+        chessSettings["scale"] = std::make_any<RayTracer::Vector3D>(
+            RayTracer::Vector3D(1, 1, 0));
+        chess->Init(chessSettings);
+
+        std::shared_ptr<Prim> plane2 =
+            Factory<Prim>::i().create("plane");
+        std::unordered_map<std::string, std::any> plane2Settings;
+        plane2Settings["position"] = std::make_any<Point3D>(Point3D(1, 2, 10));
+        plane2Settings["rotation"] = std::make_any<Vector3D>(Vector3D(0, 0, 90));
+        plane2Settings["radius"] = std::make_any<float>(10.0);
+        plane2Settings["material"] = std::make_any<std::shared_ptr<Mat>>(chess);
+        plane2->Init(plane2Settings);
+        Scene::i->ObjectHead->AddChildren(plane2);
 
         // parseCamera(raytracer);
         parsePrimitive(raytracer);

--- a/src/Parsing/Parsing.cpp
+++ b/src/Parsing/Parsing.cpp
@@ -97,7 +97,8 @@ void Parsing::parseSceneFile() {
             Factory<Prim>::i().create("plane");
         std::unordered_map<std::string, std::any> plane2Settings;
         plane2Settings["position"] = std::make_any<Point3D>(Point3D(1, 2, 10));
-        plane2Settings["rotation"] = std::make_any<Vector3D>(Vector3D(0, 0, 90));
+        plane2Settings["rotation"] =
+            std::make_any<Vector3D>(Vector3D(0, 0, 90));
         plane2Settings["radius"] = std::make_any<float>(10.0);
         plane2Settings["material"] = std::make_any<std::shared_ptr<Mat>>(chess);
         plane2->Init(plane2Settings);

--- a/src/Primitive/PrimPlane.cpp
+++ b/src/Primitive/PrimPlane.cpp
@@ -1,6 +1,9 @@
-#include "Primitive/PrimPlane.hpp"
 #include <cmath>
+#include <string>
 #include <iostream>
+#include <memory>
+
+#include "Primitive/PrimPlane.hpp"
 #include "dlLoader/dlLoader.hpp"
 #include "Consts/const.hpp"
 #include "DesignPatterns/Factory.hpp"
@@ -34,69 +37,49 @@ RayTracer::Vector3D PrimPlane::getNormalAt(RayTracer::Point3D point) {
 RayTracer::Vector3D PrimPlane::getUV(RayTracer::Point3D point) {
     RayTracer::Vector3D local = point - position;
 
-    float rx = -rotation.x * M_PI / 180.0f;
-    float ry = -rotation.y * M_PI / 180.0f;
-    float rz = -rotation.z * M_PI / 180.0f;
+    local = getRotatedVector(local);
 
-    // Rotation Z
-    local = RayTracer::Vector3D(
-        local.x * cos(rz) - local.y * sin(rz),
-        local.x * sin(rz) + local.y * cos(rz),
-        local.z
-    );
-
-    // Rotation Y
-    local = RayTracer::Vector3D(
-        local.x * cos(ry) + local.z * sin(ry),
-        local.y,
-        -local.x * sin(ry) + local.z * cos(ry)
-    );
-
-    // Rotation X
-    local = RayTracer::Vector3D(
-        local.x,
-        local.y * cos(rx) - local.z * sin(rx),
-        local.y * sin(rx) + local.z * cos(rx)
-    );
-
-    return RayTracer::Vector3D(local.x, local.y, 0);
+    return RayTracer::Vector3D(local.x, local.z, 0);
 }
 
 void PrimPlane::Init(std::unordered_map<std::string, std::any> &settings) {
     position = std::any_cast<RayTracer::Point3D>(settings["position"]);
     rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
     radius = std::any_cast<float>(settings["radius"]);
-    material = std::any_cast<std::shared_ptr<RayTracer::I_Material>>(settings["material"]);
+    material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
 }
 
-/// Fonction utilitaire : retourne la normale après rotation
 RayTracer::Vector3D PrimPlane::getRotatedNormal() const {
     RayTracer::Vector3D normal(0, 1, 0);
 
+    normal = getRotatedVector(normal);
+
+    return normal.normalize();
+}
+
+RayTracer::Vector3D PrimPlane::getRotatedVector(RayTracer::Vector3D vector)
+const {
+    RayTracer::Vector3D vec(vector.x, vector.y, vector.z);
     float rx = rotation.x * M_PI / 180.0f;
     float ry = rotation.y * M_PI / 180.0f;
     float rz = rotation.z * M_PI / 180.0f;
 
     // Axe X
-    normal = RayTracer::Vector3D(
-        normal.x,
-        normal.y * cos(rx) - normal.z * sin(rx),
-        normal.y * sin(rx) + normal.z * cos(rx)
-    );
+    vec = RayTracer::Vector3D(
+        vec.x,
+        vec.y * cos(rx) - vec.z * sin(rx),
+        vec.y * sin(rx) + vec.z * cos(rx));
 
     // Axe Y
-    normal = RayTracer::Vector3D(
-        normal.x * cos(ry) + normal.z * sin(ry),
-        normal.y,
-        -normal.x * sin(ry) + normal.z * cos(ry)
-    );
+    vec = RayTracer::Vector3D(
+        vec.x * cos(ry) + vec.z * sin(ry),
+        vec.y,
+        -vec.x * sin(ry) + vec.z * cos(ry));
 
     // Axe Z
-    normal = RayTracer::Vector3D(
-        normal.x * cos(rz) - normal.y * sin(rz),
-        normal.x * sin(rz) + normal.y * cos(rz),
-        normal.z
-    );
-
-    return normal.normalize();
+    vec = RayTracer::Vector3D(
+        vec.x * cos(rz) - vec.y * sin(rz),
+        vec.x * sin(rz) + vec.y * cos(rz),
+        vec.z);
+    return vec;
 }

--- a/src/Primitive/PrimPlane.cpp
+++ b/src/Primitive/PrimPlane.cpp
@@ -1,8 +1,6 @@
-#include <memory>
-#include <cmath>
-#include <string>
-
 #include "Primitive/PrimPlane.hpp"
+#include <cmath>
+#include <iostream>
 #include "dlLoader/dlLoader.hpp"
 #include "Consts/const.hpp"
 #include "DesignPatterns/Factory.hpp"
@@ -11,14 +9,15 @@ extern "C" std::unique_ptr<RayTracer::I_Primitive> getPrimitive() {
     return std::make_unique<PrimPlane>();
 }
 
-PrimPlane::PrimPlane() {
-}
+PrimPlane::PrimPlane() {}
 
 bool PrimPlane::hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) {
-    double denom = rotation.dot(ray.direction);
+    RayTracer::Vector3D normal = getRotatedNormal();
+
+    float denom = normal.dot(ray.direction);
     if (std::abs(denom) > 1e-6) {
-        RayTracer::Vector3D p0l0 = position - ray.origin;
-        double t = p0l0.dot(rotation) / denom;
+        RayTracer::Vector3D diff = position - ray.origin;
+        float t = diff.dot(normal) / denom;
         if (t >= 0) {
             intersection = ray.origin + ray.direction * t;
             return true;
@@ -29,18 +28,75 @@ bool PrimPlane::hits(RayTracer::Ray ray, RayTracer::Point3D &intersection) {
 
 RayTracer::Vector3D PrimPlane::getNormalAt(RayTracer::Point3D point) {
     (void)point;
-    return rotation;
+    return getRotatedNormal();
 }
 
 RayTracer::Vector3D PrimPlane::getUV(RayTracer::Point3D point) {
-    float u = point.x;
-    float v = point.z;
-    return RayTracer::Vector3D(u, v, 0);
+    RayTracer::Vector3D local = point - position;
+
+    float rx = -rotation.x * M_PI / 180.0f;
+    float ry = -rotation.y * M_PI / 180.0f;
+    float rz = -rotation.z * M_PI / 180.0f;
+
+    // Rotation Z
+    local = RayTracer::Vector3D(
+        local.x * cos(rz) - local.y * sin(rz),
+        local.x * sin(rz) + local.y * cos(rz),
+        local.z
+    );
+
+    // Rotation Y
+    local = RayTracer::Vector3D(
+        local.x * cos(ry) + local.z * sin(ry),
+        local.y,
+        -local.x * sin(ry) + local.z * cos(ry)
+    );
+
+    // Rotation X
+    local = RayTracer::Vector3D(
+        local.x,
+        local.y * cos(rx) - local.z * sin(rx),
+        local.y * sin(rx) + local.z * cos(rx)
+    );
+
+    return RayTracer::Vector3D(local.x, local.y, 0);
 }
 
 void PrimPlane::Init(std::unordered_map<std::string, std::any> &settings) {
     position = std::any_cast<RayTracer::Point3D>(settings["position"]);
     rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
     radius = std::any_cast<float>(settings["radius"]);
-    material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
+    material = std::any_cast<std::shared_ptr<RayTracer::I_Material>>(settings["material"]);
+}
+
+/// Fonction utilitaire : retourne la normale après rotation
+RayTracer::Vector3D PrimPlane::getRotatedNormal() const {
+    RayTracer::Vector3D normal(0, 1, 0);
+
+    float rx = rotation.x * M_PI / 180.0f;
+    float ry = rotation.y * M_PI / 180.0f;
+    float rz = rotation.z * M_PI / 180.0f;
+
+    // Axe X
+    normal = RayTracer::Vector3D(
+        normal.x,
+        normal.y * cos(rx) - normal.z * sin(rx),
+        normal.y * sin(rx) + normal.z * cos(rx)
+    );
+
+    // Axe Y
+    normal = RayTracer::Vector3D(
+        normal.x * cos(ry) + normal.z * sin(ry),
+        normal.y,
+        -normal.x * sin(ry) + normal.z * cos(ry)
+    );
+
+    // Axe Z
+    normal = RayTracer::Vector3D(
+        normal.x * cos(rz) - normal.y * sin(rz),
+        normal.x * sin(rz) + normal.y * cos(rz),
+        normal.z
+    );
+
+    return normal.normalize();
 }

--- a/src/Primitive/PrimPlane.hpp
+++ b/src/Primitive/PrimPlane.hpp
@@ -22,4 +22,5 @@ class PrimPlane : public RayTracer::A_Primitive {
     RayTracer::Vector3D getUV(RayTracer::Point3D point) override;
     void Init(std::unordered_map<std::string, std::any> &settings) override;
     RayTracer::Vector3D getRotatedNormal() const;
+    RayTracer::Vector3D getRotatedVector(RayTracer::Vector3D vector) const;
 };

--- a/src/Primitive/PrimPlane.hpp
+++ b/src/Primitive/PrimPlane.hpp
@@ -21,4 +21,5 @@ class PrimPlane : public RayTracer::A_Primitive {
     RayTracer::Vector3D getNormalAt(RayTracer::Point3D point) override;
     RayTracer::Vector3D getUV(RayTracer::Point3D point) override;
     void Init(std::unordered_map<std::string, std::any> &settings) override;
+    RayTracer::Vector3D getRotatedNormal() const;
 };


### PR DESCRIPTION
This pull request introduces several updates to enhance the functionality of the `PrimPlane` class, improve scene parsing, and adjust rendering settings. The most significant changes include the addition of rotation handling for planes, the introduction of a new chessboard material, and adjustments to the rendering resolution.

### Enhancements to the `PrimPlane` class:
* Added `getRotatedNormal` and `getRotatedVector` methods to handle plane rotation, enabling proper computation of normals and UV coordinates based on rotation. These methods apply rotation transformations to vectors and normalize the resulting normal vector. 
* Updated the `hits` method to use the rotated normal for intersection calculations, replacing the previous static rotation vector. (`src/Primitive/PrimPlane.cpp`
* Modified the `getNormalAt` and `getUV` methods to account for rotated vectors, ensuring accurate normal and UV mapping for transformed planes.