### PR TITLE
✨ Add -r flag to use the program in no window mode

### DIFF
--- a/include/Generation/tools.hpp
+++ b/include/Generation/tools.hpp
@@ -19,6 +19,8 @@ int generateImagePreview(sf::RenderWindow &window, my_Image &image, int pixels);
 int displayImage(sf::RenderWindow &window, my_Image &image, std::string
     sceneFile);
 void showImage(sf::RenderWindow &window, my_Image &image);
+void createPPMFile(const sf::Image& image,
+    const std::string& filename);
 
 // Compute values of the tree
 void computeTreeValues(std::shared_ptr<Prim> head,
@@ -36,3 +38,4 @@ void averageAllImages(float i, float j, my_Image &image,
 
 // Random tools
 bool hasFileChanged(std::string sceneFile);
+int renderImage(my_Image &image);

--- a/main.cpp
+++ b/main.cpp
@@ -32,21 +32,24 @@ static void waitForFileModification(std::string sceneFile) {
     }
 }
 
-static int setupAndRun(sf::RenderWindow &window, my_Image &image,
-    std::string sceneFile) {
+static int setupAndRun(my_Image &image,
+    std::string sceneFile, bool noWindowMode) {
     computeTreeValues(RayTracer::Scene::i->ObjectHead);
+    if (noWindowMode) {
+        return renderImage(image);
+    }
+    sf::RenderWindow window(sf::VideoMode(WIDTH, HEIGHT), "Ray Tracer");
     for (int i = WIDTH /2; i >= 8; i /= 2)
         generateImagePreview(window, image, i);
     return generateImage(window, image, sceneFile);
 }
 
-int testMain(std::string sceneFile) {
-    sf::RenderWindow window(sf::VideoMode(WIDTH, HEIGHT), "Ray Tracer");
+int testMain(std::string sceneFile, bool noWindowMode) {
     my_Image image;
     image.image.create(WIDTH, HEIGHT, sf::Color::Black);
 
     try {
-         return setupAndRun(window, image, sceneFile);
+         return setupAndRun(image, sceneFile, noWindowMode);
     } catch (std::exception &e) {
         std::cerr << e.what() << std::endl;
     }
@@ -64,7 +67,7 @@ int main(int argc, char **argv) {
         try {
             parser.parseArgs(argc, argv);
             parser.parseSceneFile();
-            hasFileChanged = testMain(argv[1]);
+            hasFileChanged = testMain(argv[1], parser.noWindowMode);
         }
         catch (const RayTracer::Parsing::ParsingError &e) {
             std::cerr << e.what() << std::endl;

--- a/src/Draw/createImage.cpp
+++ b/src/Draw/createImage.cpp
@@ -9,7 +9,7 @@
 #include <SFML/System.hpp>
 
 
-static void createPPMFile(const sf::Image& image,
+void createPPMFile(const sf::Image& image,
     const std::string& filename) {
     unsigned int width;
     unsigned int height;

--- a/src/Draw/draw.cpp
+++ b/src/Draw/draw.cpp
@@ -165,3 +165,21 @@ int generateImage(sf::RenderWindow &window, my_Image &image, std::string
     }
     return configChanged;
 }
+
+int renderImage(my_Image &image) {
+    std::vector<std::thread> threadVector;
+
+    for (float i = 0; i < WIDTH; i++) {
+        threadVector.emplace_back(generatePixelColumn, i,
+            std::ref(RayTracer::Camera::i()),
+            std::ref(image));
+    }
+
+    for (auto &t : threadVector) {
+        if (t.joinable())
+            t.join();
+    }
+    createPPMFile(image.image, "renders/render-" +
+        getTimestampAsString() + ".ppm");
+    return 0;
+}

--- a/src/Parsing/Parsing.cpp
+++ b/src/Parsing/Parsing.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <unordered_map>
 #include <memory>
+#include <filesystem>
 
 #include <libconfig.h++>
 
@@ -13,15 +14,24 @@ namespace RayTracer {
 
 void Parsing::parseArgs(int argc, char **argv) {
     if (argc < 2)
-        throw ParsingError("Missing scene file argument.");
-    if (argc > 2)
-        throw ParsingError("Too many arguments.");
-    if (std::string(argv[1]) == "-help") {
-        std::cout << "USAGE: ./rayTracer <SCENE_FILE>" << std::endl;
+        throw ParsingError("Missing arguments.");
+    if (std::string(argv[1]) == "--help" ||
+        std::string(argv[1]) == "-h") {
+        std::cout << "USAGE: ./rayTracer <SCENE_FILE> [-r]" << std::endl;
         std::cout << "  SCENE_FILE: scene configuration" << std::endl;
+        std::cout << "  -r: run in no window mode" << std::endl;
+
         exit(0);
     }
-    sceneFile = argv[1];
+    for (int i = 1; i < argc; ++i) {
+        if (std::string(argv[i]) == "-r")  {
+            noWindowMode = true;
+        } else if (std::filesystem::exists(argv[i])) {
+            sceneFile = argv[i];
+        } else {
+            throw ParsingError("Invalid argument: " + std::string(argv[i]));
+        }
+    }
 }
 
 void Parsing::parseSceneFile() {

--- a/src/Parsing/Parsing.hpp
+++ b/src/Parsing/Parsing.hpp
@@ -10,8 +10,9 @@ class Parsing {
      std::string sceneFile;
 
  public:
-     void parseArgs(int argc, char **argv);
-     void parseSceneFile();
+    bool noWindowMode = false;
+    void parseArgs(int argc, char **argv);
+    void parseSceneFile();
     //  void parseCamera(const libconfig::Setting &setting);
      void parsePrimitive(const libconfig::Setting &setting);
     //  void parseLights(const libconfig::Setting &setting);


### PR DESCRIPTION
This pull request introduces a "no window mode" for the ray tracing application, allowing it to render images without opening a graphical window. It also includes improvements to argument parsing, the addition of a new rendering function, and some refactoring to streamline the codebase.

### Feature Addition: No Window Mode
* Added a `noWindowMode` flag to the `Parsing` class to enable running the application without opening a graphical window. (`src/Parsing/Parsing.hpp`, `src/Parsing/Parsing.cpp`, [[1]](diffhunk://#diff-6ebf259b3f7a85e148da349275c0aeda4cab210a2d457775fe384ae6dd97244bR13) [[2]](diffhunk://#diff-540f79869abc1d7610dec85a5ff5c72afbdec4b8f25b6d0f3443f723b5be77d6L16-R34)
* Modified the `setupAndRun` and `testMain` functions to handle the `noWindowMode` flag, bypassing window creation and directly rendering the image. (`main.cpp`, [[1]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL35-R52) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL67-R70)

### New Rendering Functionality
* Introduced the `renderImage` function to handle image rendering in "no window mode." This function uses multithreading to generate pixel columns and saves the output as a `.ppm` file. (`src/Draw/draw.cpp`, [src/Draw/draw.cppR168-R185](diffhunk://#diff-c77c927d450565564c94f4c0e14068f34d23348c98249ca6ba2c0e05e9b6b18cR168-R185))
* Exposed the `createPPMFile` function in the header file for use in the new rendering workflow. (`include/Generation/tools.hpp`, `src/Draw/createImage.cpp`, [[1]](diffhunk://#diff-e18a2bba0df679c54e7e69afb3cdd04157981e82d163dcd4ed917bd3caf979baR22-R23) [[2]](diffhunk://#diff-6e97a1bbdb0a50ff7f4c8863b0b5115d72a6569c31888c6fd9d8d3baeca510ecL12-R12)

### Argument Parsing Improvements
* Enhanced argument parsing to support the `-r` flag for enabling "no window mode" and improved error handling for invalid or missing arguments. (`src/Parsing/Parsing.cpp`, [src/Parsing/Parsing.cppL16-R34](diffhunk://#diff-540f79869abc1d7610dec85a5ff5c72afbdec4b8f25b6d0f3443f723b5be77d6L16-R34))


close #74 