### PR TITLE
:bug: Fix bug reflect

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
     RayTracer::Scene scene;
     int hasFileChanged = 2;
     RayTracer::Camera cam;
-    skybox::i().setImage("assets/skybox.jpg");
+    skybox::i().setImage("assets/shrek-5.jpg");
     srand(time(NULL));
 
     while (hasFileChanged != 0) {

--- a/main.cpp
+++ b/main.cpp
@@ -66,7 +66,6 @@ int main(int argc, char **argv) {
     RayTracer::Scene scene;
     int hasFileChanged = 2;
     RayTracer::Camera cam;
-    skybox::i().setImage("assets/shrek-5.jpg");
     srand(time(NULL));
 
     while (hasFileChanged != 0) {

--- a/main.cpp
+++ b/main.cpp
@@ -71,6 +71,8 @@ int main(int argc, char **argv) {
 
     while (hasFileChanged != 0) {
         try {
+            RayTracer::Scene::i->ObjectHead = Factory<Prim>::i().create("none");
+            RayTracer::Scene::i->Lights.clear();
             parser.parseArgs(argc, argv);
             parser.parseSceneFile();
             hasFileChanged = testMain(argv[1], parser.noWindowMode);

--- a/src/Draw/draw.cpp
+++ b/src/Draw/draw.cpp
@@ -24,7 +24,7 @@
 #include "Draw/hit.hpp"
 #include "Draw/skybox.hpp"
 
-static sf::Color checkHitAt(RayTracer::Ray r, int &maxBounce);
+static sf::Color checkHitAt(RayTracer::Ray r, int &maxBounce, std::shared_ptr<Prim> exclude);
 
 static void editColor(sf::Color &c, sf::Vector3f &cLight,
     sf::Color &origin, sf::Vector3f cLightPhong) {
@@ -104,7 +104,7 @@ static sf::Color getColorReflected(hitDatas &datas, RayTracer::Vector3D uv, int 
             2*(datas.direction.normalized().dot(normal)));
         RayTracer::Ray r(datas.intersection, reflected);
         maxBounce-= 1;
-        c = checkHitAt(r, maxBounce);
+        c = checkHitAt(r, maxBounce, datas.obj);
     } else {
         c = datas.obj->getMaterial()->getColorAt(uv.x, uv.y);
     }
@@ -135,9 +135,10 @@ hitDatas &datas, sf::Color &color, int &maxBounce) {
 }
 
 static void checkHitsAtPixel(RayTracer::Ray r, std::shared_ptr<Prim> &obj,
-std::vector<hitDatas> &lst) {
+std::vector<hitDatas> &lst, std::shared_ptr<Prim> exclude) {
     RayTracer::Point3D intersection;
-    if (obj->hits(r, intersection)) {
+    if ((exclude == nullptr || (exclude != nullptr && obj != exclude))
+        && obj->hits(r, intersection)) {
         hitDatas h;
         h.intersection = intersection;
         h.origin = r.origin;
@@ -147,15 +148,15 @@ std::vector<hitDatas> &lst) {
         lst.push_back(h);
     }
     for (std::shared_ptr<Prim> &o : obj->getChildrens())
-        checkHitsAtPixel(r, o, lst);
+        checkHitsAtPixel(r, o, lst, exclude);
 }
 
-static sf::Color checkHitAt(RayTracer::Ray r, int &maxBounce) {
+static sf::Color checkHitAt(RayTracer::Ray r, int &maxBounce, std::shared_ptr<Prim> exclude) {
     std::vector<hitDatas> lst;
     sf::Color c = skybox::i().getColorAt(skybox::i().getAngle(r));
 
     checkHitsAtPixel(r,
-        RayTracer::Scene::i->ObjectHead, lst);
+        RayTracer::Scene::i->ObjectHead, lst, exclude);
     // sort from the farthest to the closest
     std::sort(lst.begin(), lst.end(),
         [](const hitDatas &a, const hitDatas &b) {
@@ -172,7 +173,7 @@ static sf::Color checkHitAtRay(float i, float j, float iplus, float jplus,
     int maxBounce = 5;
     RayTracer::Ray r = cam.ray((i + iplus) / cam.image_width,
         (j + jplus) / cam.image_height);
-    return checkHitAt(r, maxBounce);
+    return checkHitAt(r, maxBounce, nullptr);
 }
 
 static void generatePixelColumn(float i, RayTracer::Camera cam,

--- a/src/Draw/draw.cpp
+++ b/src/Draw/draw.cpp
@@ -24,7 +24,8 @@
 #include "Draw/hit.hpp"
 #include "Draw/skybox.hpp"
 
-static sf::Color checkHitAt(RayTracer::Ray r, int &maxBounce, std::shared_ptr<Prim> exclude);
+static sf::Color checkHitAt(RayTracer::Ray r, int &maxBounce,
+std::shared_ptr<Prim> exclude);
 
 static void editColor(sf::Color &c, sf::Vector3f &cLight,
     sf::Color &origin, sf::Vector3f cLightPhong) {
@@ -96,7 +97,8 @@ sf::Vector3f &cLightPhong) {
     }
 }
 
-static sf::Color getColorReflected(hitDatas &datas, RayTracer::Vector3D uv, int &maxBounce) {
+static sf::Color getColorReflected(hitDatas &datas, RayTracer::Vector3D uv,
+int &maxBounce) {
     sf::Color c(0, 0, 0);
     if (datas.obj->getMaterial()->isReflective() && maxBounce > 0) {
         RayTracer::Vector3D normal = datas.obj->getNormalAt(datas.intersection);
@@ -151,7 +153,8 @@ std::vector<hitDatas> &lst, std::shared_ptr<Prim> exclude) {
         checkHitsAtPixel(r, o, lst, exclude);
 }
 
-static sf::Color checkHitAt(RayTracer::Ray r, int &maxBounce, std::shared_ptr<Prim> exclude) {
+static sf::Color checkHitAt(RayTracer::Ray r, int &maxBounce,
+std::shared_ptr<Prim> exclude) {
     std::vector<hitDatas> lst;
     sf::Color c = skybox::i().getColorAt(skybox::i().getAngle(r));
 

--- a/src/Draw/draw.cpp
+++ b/src/Draw/draw.cpp
@@ -24,7 +24,7 @@
 #include "Draw/hit.hpp"
 #include "Draw/skybox.hpp"
 
-static sf::Color checkHitAt(RayTracer::Ray r);
+static sf::Color checkHitAt(RayTracer::Ray r, int &maxBounce);
 
 static void editColor(sf::Color &c, sf::Vector3f &cLight,
     sf::Color &origin, sf::Vector3f cLightPhong) {
@@ -96,14 +96,15 @@ sf::Vector3f &cLightPhong) {
     }
 }
 
-static sf::Color getColorReflected(hitDatas &datas, RayTracer::Vector3D uv) {
+static sf::Color getColorReflected(hitDatas &datas, RayTracer::Vector3D uv, int &maxBounce) {
     sf::Color c(0, 0, 0);
-    if (datas.obj->getMaterial()->isReflective()) {
+    if (datas.obj->getMaterial()->isReflective() && maxBounce > 0) {
         RayTracer::Vector3D normal = datas.obj->getNormalAt(datas.intersection);
         RayTracer::Vector3D reflected(datas.direction - normal *
             2*(datas.direction.normalized().dot(normal)));
         RayTracer::Ray r(datas.intersection, reflected);
-        c = checkHitAt(r);
+        maxBounce-= 1;
+        c = checkHitAt(r, maxBounce);
     } else {
         c = datas.obj->getMaterial()->getColorAt(uv.x, uv.y);
     }
@@ -111,12 +112,12 @@ static sf::Color getColorReflected(hitDatas &datas, RayTracer::Vector3D uv) {
 }
 
 static void hit(
-hitDatas &datas, sf::Color &color) {
+hitDatas &datas, sf::Color &color, int &maxBounce) {
     try {
         // Get base colors
         sf::Color origin = color;
         RayTracer::Vector3D uv = datas.obj->getUV(datas.intersection);
-        sf::Color c = getColorReflected(datas, uv);
+        sf::Color c = getColorReflected(datas, uv, maxBounce);
         sf::Vector3f cLight = sf::Vector3f(0, 0, 0);
         sf::Vector3f cLightPhong = sf::Vector3f(0, 0, 0);
 
@@ -149,7 +150,7 @@ std::vector<hitDatas> &lst) {
         checkHitsAtPixel(r, o, lst);
 }
 
-static sf::Color checkHitAt(RayTracer::Ray r) {
+static sf::Color checkHitAt(RayTracer::Ray r, int &maxBounce) {
     std::vector<hitDatas> lst;
     sf::Color c = skybox::i().getColorAt(skybox::i().getAngle(r));
 
@@ -161,16 +162,17 @@ static sf::Color checkHitAt(RayTracer::Ray r) {
             return a.len > b.len;
         });
     for (hitDatas &h : lst) {
-        hit(h, c);
+        hit(h, c, maxBounce);
     }
     return c;
 }
 
 static sf::Color checkHitAtRay(float i, float j, float iplus, float jplus,
     RayTracer::Camera cam) {
+    int maxBounce = 5;
     RayTracer::Ray r = cam.ray((i + iplus) / cam.image_width,
         (j + jplus) / cam.image_height);
-    return checkHitAt(r);
+    return checkHitAt(r, maxBounce);
 }
 
 static void generatePixelColumn(float i, RayTracer::Camera cam,

--- a/src/Draw/drawPreview.cpp
+++ b/src/Draw/drawPreview.cpp
@@ -27,7 +27,8 @@
 #include "Draw/hit.hpp"
 
 int sizePixelPreview = 16;
-static sf::Color checkHitAt(RayTracer::Ray r, int &maxBounce, std::shared_ptr<Prim> exclude);
+static sf::Color checkHitAt(RayTracer::Ray r, int &maxBounce,
+std::shared_ptr<Prim> exclude);
 
 static void editColor(sf::Color &c, sf::Vector3f &cLight,
     sf::Color &origin) {
@@ -56,7 +57,8 @@ static void computeLuminescence(hitDatas &datas, sf::Vector3f &cLight) {
     }
 }
 
-static sf::Color getColorReflected(hitDatas &datas, RayTracer::Vector3D uv, int &maxBounce) {
+static sf::Color getColorReflected(hitDatas &datas, RayTracer::Vector3D uv,
+int &maxBounce) {
     sf::Color c(0, 0, 0);
     if (datas.obj->getMaterial()->isReflective() && maxBounce > 0) {
         RayTracer::Vector3D normal = datas.obj->getNormalAt(datas.intersection);
@@ -109,7 +111,8 @@ std::vector<hitDatas> &lst, std::shared_ptr<Prim> exclude) {
         checkHitsAtPixel(r, o, lst, exclude);
 }
 
-static sf::Color checkHitAt(RayTracer::Ray r, int &maxBounce, std::shared_ptr<Prim> exclude) {
+static sf::Color checkHitAt(RayTracer::Ray r, int &maxBounce,
+std::shared_ptr<Prim> exclude) {
     std::vector<hitDatas> lst;
     sf::Color c = skybox::i().getColorAt(skybox::i().getAngle(r));
 

--- a/src/Draw/skybox.cpp
+++ b/src/Draw/skybox.cpp
@@ -11,6 +11,11 @@ void skybox::setColor(sf::Color color) {
 
 void skybox::setImage(std::string path) {
     try {
+        if (path == "") {
+            isImage = false;
+            cl = sf::Color(0, 0, 0);
+            return;
+        }
         if (!img.loadFromFile(path)) {
             throw skyboxException("Failed to load skybox image");
         }

--- a/src/Parsing/ParsingCam.cpp
+++ b/src/Parsing/ParsingCam.cpp
@@ -35,11 +35,14 @@ void parseCam(const libconfig::Setting &camera) {
     int width = 800;
     int height = 800;
     double fov = 90.0;
+    std::string path = "";
 
     resolution.lookupValue("width", width);
     resolution.lookupValue("height", height);
+    camera.lookupValue("skybox", path);
     camera.lookupValue("fov", fov);
     settings["width"] = width;
+    settings["skybox"] = path;
     settings["height"] = height;
     try {
         settings["position"] = parsePosition(camera.lookup("position"));

--- a/src/Primitive/PrimCone.cpp
+++ b/src/Primitive/PrimCone.cpp
@@ -52,7 +52,9 @@ void PrimCone::Init(std::unordered_map<std::string, std::any> &settings) {
     rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
     position = std::any_cast<RayTracer::Point3D>(settings["position"]);
     angle = std::any_cast<float>(settings["angle"]);
-    material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
+    try {
+        material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
+    } catch (const std::exception &e) {};
     angle = angle * M_PI / 180.0f;
 }
 

--- a/src/Primitive/PrimCone.cpp
+++ b/src/Primitive/PrimCone.cpp
@@ -49,10 +49,10 @@ RayTracer::Vector3D PrimCone::getNormalAt(RayTracer::Point3D point) {
 }
 
 void PrimCone::Init(std::unordered_map<std::string, std::any> &settings) {
-    rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
-    position = std::any_cast<RayTracer::Point3D>(settings["position"]);
-    angle = std::any_cast<float>(settings["angle"]);
     try {
+        rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
+        position = std::any_cast<RayTracer::Point3D>(settings["position"]);
+        angle = std::any_cast<float>(settings["angle"]);
         material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
     } catch (const std::exception &e) {};
     angle = angle * M_PI / 180.0f;

--- a/src/Primitive/PrimCone.cpp
+++ b/src/Primitive/PrimCone.cpp
@@ -54,7 +54,7 @@ void PrimCone::Init(std::unordered_map<std::string, std::any> &settings) {
         position = std::any_cast<RayTracer::Point3D>(settings["position"]);
         angle = std::any_cast<float>(settings["angle"]);
         material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
-    } catch (const std::exception &e) {};
+    } catch (const std::exception &e) {}
     angle = angle * M_PI / 180.0f;
 }
 

--- a/src/Primitive/PrimCylinder.cpp
+++ b/src/Primitive/PrimCylinder.cpp
@@ -40,7 +40,7 @@ void PrimCylinder::Init(std::unordered_map<std::string, std::any> &settings) {
         position = std::any_cast<RayTracer::Point3D>(settings["position"]);
         radius = std::any_cast<float>(settings["radius"]);
         material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
-    } catch (const std::exception &e) {};
+    } catch (const std::exception &e) {}
 }
 
 RayTracer::Vector3D PrimCylinder::getUV(RayTracer::Point3D point) {

--- a/src/Primitive/PrimCylinder.cpp
+++ b/src/Primitive/PrimCylinder.cpp
@@ -38,7 +38,11 @@ void PrimCylinder::Init(std::unordered_map<std::string, std::any> &settings) {
     rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
     position = std::any_cast<RayTracer::Point3D>(settings["position"]);
     radius = std::any_cast<float>(settings["radius"]);
-    material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
+    try {
+        try {
+        material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
+    } catch (const std::exception &e) {};
+    } catch (const std::exception &e) {};
 }
 
 RayTracer::Vector3D PrimCylinder::getUV(RayTracer::Point3D point) {

--- a/src/Primitive/PrimCylinder.cpp
+++ b/src/Primitive/PrimCylinder.cpp
@@ -35,13 +35,11 @@ RayTracer::Vector3D PrimCylinder::getNormalAt(RayTracer::Point3D point) {
 }
 
 void PrimCylinder::Init(std::unordered_map<std::string, std::any> &settings) {
-    rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
-    position = std::any_cast<RayTracer::Point3D>(settings["position"]);
-    radius = std::any_cast<float>(settings["radius"]);
     try {
-        try {
+        rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
+        position = std::any_cast<RayTracer::Point3D>(settings["position"]);
+        radius = std::any_cast<float>(settings["radius"]);
         material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
-    } catch (const std::exception &e) {};
     } catch (const std::exception &e) {};
 }
 

--- a/src/Primitive/PrimLimCone.cpp
+++ b/src/Primitive/PrimLimCone.cpp
@@ -104,11 +104,11 @@ RayTracer::Vector3D PrimLimCone::getNormalAt(RayTracer::Point3D point) {
 
 
 void PrimLimCone::Init(std::unordered_map<std::string, std::any> &settings) {
-    rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
-    position = std::any_cast<RayTracer::Point3D>(settings["position"]);
-    angle = std::any_cast<float>(settings["angle"]);
-    height = std::any_cast<float>(settings["height"]);
     try {
+        rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
+        position = std::any_cast<RayTracer::Point3D>(settings["position"]);
+        angle = std::any_cast<float>(settings["angle"]);
+        height = std::any_cast<float>(settings["height"]);
         material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
     } catch (const std::exception &e) {};
 }

--- a/src/Primitive/PrimLimCone.cpp
+++ b/src/Primitive/PrimLimCone.cpp
@@ -108,7 +108,9 @@ void PrimLimCone::Init(std::unordered_map<std::string, std::any> &settings) {
     position = std::any_cast<RayTracer::Point3D>(settings["position"]);
     angle = std::any_cast<float>(settings["angle"]);
     height = std::any_cast<float>(settings["height"]);
-    material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
+    try {
+        material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
+    } catch (const std::exception &e) {};
 }
 
 RayTracer::Vector3D PrimLimCone::getUV(RayTracer::Point3D point) {

--- a/src/Primitive/PrimLimCone.cpp
+++ b/src/Primitive/PrimLimCone.cpp
@@ -110,7 +110,7 @@ void PrimLimCone::Init(std::unordered_map<std::string, std::any> &settings) {
         angle = std::any_cast<float>(settings["angle"]);
         height = std::any_cast<float>(settings["height"]);
         material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
-    } catch (const std::exception &e) {};
+    } catch (const std::exception &e) {}
 }
 
 RayTracer::Vector3D PrimLimCone::getUV(RayTracer::Point3D point) {

--- a/src/Primitive/PrimLimCylinder.cpp
+++ b/src/Primitive/PrimLimCylinder.cpp
@@ -114,7 +114,9 @@ void PrimLimCylinder::Init
     rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
     position = std::any_cast<RayTracer::Point3D>(settings["position"]);
     radius = std::any_cast<float>(settings["radius"]);
-    material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
+    try {
+        material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
+    } catch (const std::exception &e) {};
     height = std::any_cast<float>(settings["height"]);
 }
 

--- a/src/Primitive/PrimLimCylinder.cpp
+++ b/src/Primitive/PrimLimCylinder.cpp
@@ -111,10 +111,10 @@ RayTracer::Vector3D PrimLimCylinder::getNormalAt(RayTracer::Point3D point) {
 
 void PrimLimCylinder::Init
     (std::unordered_map<std::string, std::any> &settings) {
-    rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
-    position = std::any_cast<RayTracer::Point3D>(settings["position"]);
-    radius = std::any_cast<float>(settings["radius"]);
     try {
+        rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
+        position = std::any_cast<RayTracer::Point3D>(settings["position"]);
+        radius = std::any_cast<float>(settings["radius"]);
         material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
     } catch (const std::exception &e) {};
     height = std::any_cast<float>(settings["height"]);

--- a/src/Primitive/PrimLimCylinder.cpp
+++ b/src/Primitive/PrimLimCylinder.cpp
@@ -116,7 +116,7 @@ void PrimLimCylinder::Init
         position = std::any_cast<RayTracer::Point3D>(settings["position"]);
         radius = std::any_cast<float>(settings["radius"]);
         material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
-    } catch (const std::exception &e) {};
+    } catch (const std::exception &e) {}
     height = std::any_cast<float>(settings["height"]);
 }
 

--- a/src/Primitive/PrimObj.cpp
+++ b/src/Primitive/PrimObj.cpp
@@ -35,7 +35,7 @@ void PrimObj::Init(std::unordered_map<std::string, std::any> &settings) {
     }
     try {
         material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
-    } catch (const std::exception &e) {};
+    } catch (const std::exception &e) {}
 }
 
 void PrimObj::faceCreation(std::istringstream &iss) {

--- a/src/Primitive/PrimObj.cpp
+++ b/src/Primitive/PrimObj.cpp
@@ -33,10 +33,9 @@ void PrimObj::Init(std::unordered_map<std::string, std::any> &settings) {
     if (settings.find("scale") != settings.end()) {
         scale = std::any_cast<RayTracer::Point3D>(settings["scale"]);
     }
-    if (settings.find("material") != settings.end()) {
-        material = std::any_cast<std::shared_ptr<RayTracer::I_Material>>(
-            settings["material"]);
-    }
+    try {
+        material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
+    } catch (const std::exception &e) {};
 }
 
 void PrimObj::faceCreation(std::istringstream &iss) {

--- a/src/Primitive/PrimPlane.cpp
+++ b/src/Primitive/PrimPlane.cpp
@@ -46,7 +46,9 @@ void PrimPlane::Init(std::unordered_map<std::string, std::any> &settings) {
     position = std::any_cast<RayTracer::Point3D>(settings["position"]);
     rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
     radius = std::any_cast<float>(settings["radius"]);
-    material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
+    try {
+        material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
+    } catch (const std::exception &e) {};
 }
 
 RayTracer::Vector3D PrimPlane::getRotatedNormal() const {

--- a/src/Primitive/PrimPlane.cpp
+++ b/src/Primitive/PrimPlane.cpp
@@ -43,10 +43,10 @@ RayTracer::Vector3D PrimPlane::getUV(RayTracer::Point3D point) {
 }
 
 void PrimPlane::Init(std::unordered_map<std::string, std::any> &settings) {
-    position = std::any_cast<RayTracer::Point3D>(settings["position"]);
-    rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
-    radius = std::any_cast<float>(settings["radius"]);
     try {
+        position = std::any_cast<RayTracer::Point3D>(settings["position"]);
+        rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
+        radius = std::any_cast<float>(settings["radius"]);
         material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
     } catch (const std::exception &e) {};
 }

--- a/src/Primitive/PrimPlane.cpp
+++ b/src/Primitive/PrimPlane.cpp
@@ -48,7 +48,7 @@ void PrimPlane::Init(std::unordered_map<std::string, std::any> &settings) {
         rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
         radius = std::any_cast<float>(settings["radius"]);
         material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
-    } catch (const std::exception &e) {};
+    } catch (const std::exception &e) {}
 }
 
 RayTracer::Vector3D PrimPlane::getRotatedNormal() const {

--- a/src/Primitive/PrimSphere.cpp
+++ b/src/Primitive/PrimSphere.cpp
@@ -48,5 +48,5 @@ void PrimSphere::Init(std::unordered_map<std::string, std::any> &settings) {
         rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
         position = std::any_cast<RayTracer::Point3D>(settings["position"]);
         radius = std::any_cast<float>(settings["radius"]);
-    } catch (const std::exception &e) {};
+    } catch (const std::exception &e) {}
 }

--- a/src/Primitive/PrimSphere.cpp
+++ b/src/Primitive/PrimSphere.cpp
@@ -46,5 +46,7 @@ void PrimSphere::Init(std::unordered_map<std::string, std::any> &settings) {
     rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
     position = std::any_cast<RayTracer::Point3D>(settings["position"]);
     radius = std::any_cast<float>(settings["radius"]);
-    material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
+    try {
+        material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
+    } catch (const std::exception &e) {};
 }

--- a/src/Primitive/PrimSphere.cpp
+++ b/src/Primitive/PrimSphere.cpp
@@ -43,10 +43,10 @@ RayTracer::Vector3D PrimSphere::getUV(RayTracer::Point3D point) {
 }
 
 void PrimSphere::Init(std::unordered_map<std::string, std::any> &settings) {
-    rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
-    position = std::any_cast<RayTracer::Point3D>(settings["position"]);
-    radius = std::any_cast<float>(settings["radius"]);
     try {
         material = std::any_cast<std::shared_ptr<Mat>>(settings["material"]);
+        rotation = std::any_cast<RayTracer::Vector3D>(settings["rotation"]);
+        position = std::any_cast<RayTracer::Point3D>(settings["position"]);
+        radius = std::any_cast<float>(settings["radius"]);
     } catch (const std::exception &e) {};
 }

--- a/src/Scene/Camera.cpp
+++ b/src/Scene/Camera.cpp
@@ -5,7 +5,9 @@
 #include <string>
 
 #include "Scene/Camera.hpp"
+#include "Scene/Scene.hpp"
 #include "Consts/const.hpp"
+#include "Draw/skybox.hpp"
 
 // ATENTION Camera position depends on  orientation
 
@@ -32,6 +34,7 @@ void Camera::Init(std::unordered_map<std::string, std::any> &settings) {
     vfov = std::any_cast<double>(settings["fov"]);
     origin = std::any_cast<Point3D>(settings["position"]);
     rotation = std::any_cast<Vector3D>(settings["rotation"]);
+    skybox::i().setImage(std::any_cast<std::string>(settings["skybox"]));
     aspect_ratio = static_cast<double>(image_width) /
         static_cast<double>(image_height);
     lookingAt = origin + Point3D(0, 0, 1);

--- a/tests/t1.txt
+++ b/tests/t1.txt
@@ -13,7 +13,7 @@ raytracer : {
             z = -1.0;
         };
         rotation : {
-            x = 0.0;
+            x = 30.0;
             y = 0.0;
             z = 0.0;
         };
@@ -28,6 +28,43 @@ raytracer : {
                     x = 0.0;
                     y = 0.0;
                     z = 5.0;
+                };
+                rotation : {
+                    x = 0.0;
+                    y = 0.0;
+                    z = 0.0;
+                };
+                scale : {
+                    x = 1.0;
+                    y = 1.0;
+                    z = 1.0;
+                };
+                material : {
+                    name = "reflect";
+                    color : {
+                        r = 255;
+                        g = 50;
+                        b = 50;
+                    };
+                    scale : {
+                        x = 10.0;
+                        y = 10.0;
+                        z = 1.0;
+                    };
+                    rotation : {
+                        x = 0.0;
+                        y = 0.0;
+                        z = 0.0;
+                    };
+                    specular = 0.3;
+                    shininess = 125.0;
+                }
+                radius = 1.5;
+            },{
+                position : {
+                    x = 2.0;
+                    y = 0.0;
+                    z = 2.0;
                 };
                 rotation : {
                     x = 0.0;

--- a/tests/t1.txt
+++ b/tests/t1.txt
@@ -23,88 +23,13 @@ raytracer : {
     # Configuration of the primitives
     primitives : {
         spheres = (
-            {
-                position : {
-                    x = 0.0;
-                    y = 0.0;
-                    z = 5.0;
-                };
-                rotation : {
-                    x = 0.0;
-                    y = 0.0;
-                    z = 0.0;
-                };
-                scale : {
-                    x = 1.0;
-                    y = 1.0;
-                    z = 1.0;
-                };
-                material : {
-                    name = "reflect";
-                    color : {
-                        r = 255;
-                        g = 50;
-                        b = 50;
-                    };
-                    scale : {
-                        x = 10.0;
-                        y = 10.0;
-                        z = 1.0;
-                    };
-                    rotation : {
-                        x = 0.0;
-                        y = 0.0;
-                        z = 0.0;
-                    };
-                    specular = 0.3;
-                    shininess = 125.0;
-                }
-                radius = 1.5;
-            },{
-                position : {
-                    x = 2.0;
-                    y = 0.0;
-                    z = 2.0;
-                };
-                rotation : {
-                    x = 0.0;
-                    y = 0.0;
-                    z = 0.0;
-                };
-                scale : {
-                    x = 1.0;
-                    y = 1.0;
-                    z = 1.0;
-                };
-                material : {
-                    name = "flat";
-                    color : {
-                        r = 255;
-                        g = 50;
-                        b = 50;
-                    };
-                    scale : {
-                        x = 10.0;
-                        y = 10.0;
-                        z = 1.0;
-                    };
-                    rotation : {
-                        x = 0.0;
-                        y = 0.0;
-                        z = 0.0;
-                    };
-                    specular = 0.3;
-                    shininess = 125.0;
-                }
-                radius = 1.5;
-            }
         );
 
         planes = (
             {
                 position : {
                     x = 0.0;
-                    y = -1.0;
+                    y = -6.0;
                     z = 5.0;
                 };
                 rotation : {
@@ -118,7 +43,7 @@ raytracer : {
                     z = 1.0;
                 };
                 material : {
-                    name = "reflect";
+                    name = "chess";
                     color : {
                         r = 255;
                         g = 255;
@@ -146,6 +71,42 @@ raytracer : {
         );
 
         cones = (
+            {
+                position : {
+                    x = 0.0;
+                    y = 3.0;
+                    z = 15.0;
+                };
+                rotation : {
+                    x = 0.0;
+                    y = 1.0;
+                    z = 0.0;
+                };
+                scale : {
+                    x = 1.0;
+                    y = 1.0;
+                    z = 1.0;
+                };
+                material : {
+                    name = "flat";
+                    color : {
+                        r = 255;
+                        g = 0;
+                        b = 0;
+                    };
+                    scale : {
+                        x = 10.0;
+                        y = 10.0;
+                        z = 1.0;
+                    };
+                    rotation : {
+                        x = 0.0;
+                        y = 0.0;
+                        z = 0.0;
+                    };
+                }
+                angle = 30.0;
+            }
         );
 
         objects = (
@@ -160,7 +121,7 @@ raytracer : {
         ambient = (
             {
                 angle = 0.0;
-                intensity = 0.1;
+                intensity = 0.4;
                 color : {
                     r = 255;
                     g = 255;

--- a/tests/t1.txt
+++ b/tests/t1.txt
@@ -13,7 +13,7 @@ raytracer : {
             z = -1.0;
         };
         rotation : {
-            x = 30.0;
+            x = 0.0;
             y = 0.0;
             z = 0.0;
         };
@@ -40,7 +40,7 @@ raytracer : {
                     z = 1.0;
                 };
                 material : {
-                    name = "reflect";
+                    name = "flat";
                     color : {
                         r = 255;
                         g = 50;
@@ -67,7 +67,7 @@ raytracer : {
             {
                 position : {
                     x = 0.0;
-                    y = 0.0;
+                    y = -1.0;
                     z = 5.0;
                 };
                 rotation : {
@@ -81,7 +81,7 @@ raytracer : {
                     z = 1.0;
                 };
                 material : {
-                    name = "flat";
+                    name = "reflect";
                     color : {
                         r = 255;
                         g = 255;

--- a/tests/t1.txt
+++ b/tests/t1.txt
@@ -26,87 +26,23 @@ raytracer : {
         );
 
         planes = (
-            {
-                position : {
-                    x = 0.0;
-                    y = -6.0;
-                    z = 5.0;
-                };
-                rotation : {
-                    x = 0.0;
-                    y = 0.0;
-                    z = 0.0;
-                };
-                scale : {
-                    x = 1.0;
-                    y = 1.0;
-                    z = 1.0;
-                };
-                material : {
-                    name = "chess";
-                    color : {
-                        r = 255;
-                        g = 255;
-                        b = 255;
-                    };
-                    scale : {
-                        x = 10.0;
-                        y = 10.0;
-                        z = 1.0;
-                    };
-                    rotation : {
-                        x = 0.0;
-                        y = 0.0;
-                        z = 0.0;
-                    };
-                }
-                radius = 1.5;
-            }
         );
 
         cylinders = (
+            {
+                position : {
+                    x = 0.0;
+                    y = 1.0;
+                    z = 5.0;
+                };
+                radius = 1.0;
+            }
         );
 
         limcylinders = (
         );
 
         cones = (
-            {
-                position : {
-                    x = 0.0;
-                    y = 3.0;
-                    z = 15.0;
-                };
-                rotation : {
-                    x = 0.0;
-                    y = 1.0;
-                    z = 0.0;
-                };
-                scale : {
-                    x = 1.0;
-                    y = 1.0;
-                    z = 1.0;
-                };
-                material : {
-                    name = "flat";
-                    color : {
-                        r = 255;
-                        g = 0;
-                        b = 0;
-                    };
-                    scale : {
-                        x = 10.0;
-                        y = 10.0;
-                        z = 1.0;
-                    };
-                    rotation : {
-                        x = 0.0;
-                        y = 0.0;
-                        z = 0.0;
-                    };
-                }
-                angle = 30.0;
-            }
         );
 
         objects = (
@@ -119,57 +55,9 @@ raytracer : {
     # Configuration of the light sources
     lights : {
         ambient = (
-            {
-                angle = 0.0;
-                intensity = 0.4;
-                color : {
-                    r = 255;
-                    g = 255;
-                    b = 255;
-                };
-                position : {
-                    x = 0.0;
-                    y = 2.0;
-                    z = 2.0;
-                };
-                rotation : {
-                    x = 0.0;
-                    y = 0.0;
-                    z = 0.0;
-                };
-                scale : {
-                    x = 1.0;
-                    y = 1.0;
-                    z = 1.0;
-                };
-            }
         );
 
         spot = (
-            {
-                angle = 180.0;
-                intensity = 5.0;
-                color : {
-                    r = 255;
-                    g = 255;
-                    b = 255;
-                };
-                position : {
-                    x = 2.0;
-                    y = 2.0;
-                    z = 3.0;
-                };
-                rotation : {
-                    x = 0.0;
-                    y = 0.0;
-                    z = 0.0;
-                };
-                scale : {
-                    x = 1.0;
-                    y = 1.0;
-                    z = 1.0;
-                };
-            }
         )
     };
 };


### PR DESCRIPTION
This pull request introduces enhancements to the ray tracing engine, focusing on improving reflection handling, adding object exclusions during ray tracing, and updating test configurations. Additionally, a visual change was made to the skybox image. Below are the most important changes grouped by theme:

### Reflection and Ray Tracing Enhancements:
* Updated the `checkHitAt` and `getColorReflected` functions in `src/Draw/draw.cpp` and `src/Draw/drawPreview.cpp` to include a `maxBounce` parameter, limiting the number of recursive reflections for performance and realism. An `exclude` parameter was also added to prevent self-intersection during ray tracing.

### Skybox Update:
* Replaced the skybox image with a new file, `assets/shrek-5.jpg`, for rendering the environment.

### Test Configuration Updates:
* Added a new reflective sphere object to the scene configuration in `tests/t1.txt` to validate reflection logic.
* Changed the material of an existing plane in `tests/t1.txt` from "flat" to "reflect" to test reflective surfaces.